### PR TITLE
Only check whether new codes have NULL fields

### DIFF
--- a/alarm_controller.py
+++ b/alarm_controller.py
@@ -193,7 +193,7 @@ class AlarmController:
         distinct_redshift_count = int(redshift_counts[1])
         if self.run_added_tests:
             null_itype_codes = self.redshift_client.execute_query(
-                build_redshift_itype_null_query(itype_table))
+                build_redshift_itype_null_query(itype_table, self.yesterday))
         self.redshift_client.close_connection()
 
         if sierra_count != total_redshift_count:
@@ -231,7 +231,8 @@ class AlarmController:
         distinct_redshift_count = int(redshift_counts[1])
         if self.run_added_tests:
             null_location_codes = self.redshift_client.execute_query(
-                build_redshift_location_null_query(location_table))
+                build_redshift_location_null_query(location_table,
+                                                   self.yesterday))
         self.redshift_client.close_connection()
 
         if sierra_count != total_redshift_count:
@@ -272,10 +273,11 @@ class AlarmController:
         distinct_redshift_count = int(redshift_counts[1])
         if self.run_added_tests:
             null_stat_group_codes = self.redshift_client.execute_query(
-                build_redshift_stat_group_null_query(stat_group_table))
+                build_redshift_stat_group_null_query(stat_group_table,
+                                                     self.yesterday))
             stat_groups_without_locations = self.redshift_client.execute_query(
                 build_redshift_stat_group_location_query(
-                    stat_group_table, location_table))
+                    stat_group_table, location_table, self.yesterday))
         self.redshift_client.close_connection()
 
         if sierra_count != total_redshift_count:

--- a/query_helper.py
+++ b/query_helper.py
@@ -57,25 +57,25 @@ _REDSHIFT_CODE_COUNTS_QUERY = (
 _REDSHIFT_ITYPE_NULL_QUERY = '''
     SELECT code FROM {table}
     WHERE code != 0
-        AND deletion_date IS NULL
+        AND creation_date = '{date}'
         AND (is_research IS NULL
             OR age_category IS NULL
             OR is_print IS NULL);'''
 
 _REDSHIFT_LOCATION_NULL_QUERY = '''
     SELECT location_code FROM {table}
-    WHERE deletion_date IS NULL
-        AND research_branch IS NULL
-        AND shelving_category IS NULL;'''
+    WHERE creation_date = '{date}'
+        AND shelving_category IS NULL
+        AND (research_branch IS NULL OR is_mixed_use = TRUE);'''
 
 _REDSHIFT_STAT_GROUP_NULL_QUERY = '''
     SELECT stat_group_code FROM {table}
-    WHERE deletion_date IS NULL
+    WHERE creation_date = '{date}'
         AND normalized_branch_code IS NULL;'''
 
 _REDSHIFT_STAT_GROUP_LOCATION_QUERY = '''
     SELECT stat_group_code FROM {stat_group_table}
-    WHERE deletion_date IS NULL
+    WHERE creation_date = '{date}'
         AND normalized_branch_code NOT IN
             (SELECT location_code FROM {location_table}
             WHERE deletion_date IS NULL);'''
@@ -129,18 +129,22 @@ def build_redshift_code_counts_query(code, table):
     return _REDSHIFT_CODE_COUNTS_QUERY.format(code=code, table=table)
 
 
-def build_redshift_itype_null_query(itype_table):
-    return _REDSHIFT_ITYPE_NULL_QUERY.format(table=itype_table)
+def build_redshift_itype_null_query(itype_table, date):
+    return _REDSHIFT_ITYPE_NULL_QUERY.format(table=itype_table, date=date)
 
 
-def build_redshift_location_null_query(location_table):
-    return _REDSHIFT_LOCATION_NULL_QUERY.format(table=location_table)
+def build_redshift_location_null_query(location_table, date):
+    return _REDSHIFT_LOCATION_NULL_QUERY.format(
+        table=location_table, date=date)
 
 
-def build_redshift_stat_group_null_query(stat_group_table):
-    return _REDSHIFT_STAT_GROUP_NULL_QUERY.format(table=stat_group_table)
+def build_redshift_stat_group_null_query(stat_group_table, date):
+    return _REDSHIFT_STAT_GROUP_NULL_QUERY.format(
+        table=stat_group_table, date=date)
 
 
-def build_redshift_stat_group_location_query(stat_group_table, location_table):
+def build_redshift_stat_group_location_query(stat_group_table, location_table,
+                                             date):
     return _REDSHIFT_STAT_GROUP_LOCATION_QUERY.format(
-        stat_group_table=stat_group_table, location_table=location_table)
+        stat_group_table=stat_group_table, location_table=location_table,
+        date=date)

--- a/tests/test_alarm_controller.py
+++ b/tests/test_alarm_controller.py
@@ -322,7 +322,7 @@ class TestAlarmController:
         mock_redshift_counts_query.assert_called_once_with(
             'code', 'sierra_itype_codes_test_redshift_db')
         mock_redshift_null_query.assert_called_once_with(
-            'sierra_itype_codes_test_redshift_db')
+            'sierra_itype_codes_test_redshift_db', '2023-05-31')
         test_instance.redshift_client.execute_query.assert_has_calls([
             mocker.call('redshift code counts query'),
             mocker.call('redshift null query')])
@@ -403,7 +403,7 @@ class TestAlarmController:
         mock_redshift_counts_query.assert_called_once_with(
             'location_code', 'sierra_location_codes_test_redshift_db')
         mock_redshift_null_query.assert_called_once_with(
-            'sierra_location_codes_test_redshift_db')
+            'sierra_location_codes_test_redshift_db', '2023-05-31')
         test_instance.redshift_client.execute_query.assert_has_calls([
             mocker.call('redshift code counts query'),
             mocker.call('redshift null query')])
@@ -488,10 +488,10 @@ class TestAlarmController:
         mock_redshift_counts_query.assert_called_once_with(
             'stat_group_code', 'sierra_stat_group_codes_test_redshift_db')
         mock_redshift_null_query.assert_called_once_with(
-            'sierra_stat_group_codes_test_redshift_db')
+            'sierra_stat_group_codes_test_redshift_db', '2023-05-31')
         mock_redshift_unknown_locations_query.assert_called_once_with(
             'sierra_stat_group_codes_test_redshift_db',
-            'sierra_location_codes_test_redshift_db')
+            'sierra_location_codes_test_redshift_db', '2023-05-31')
         test_instance.redshift_client.execute_query.assert_has_calls([
             mocker.call('redshift code counts query'),
             mocker.call('redshift null query'),


### PR DESCRIPTION
Some codes will be NULL while we figure out what they should be or will end up being NULL forever and we only want to be alerted once.