### PR TITLE
Add holds alarm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ run:
 	python -c 'import lambda_function; lambda_function.lambda_handler(None, None)'
 
 test:
-	pytest
+	pytest tests -W ignore::DeprecationWarning
 
 lint:
 	flake8 --exclude *env,package

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ This repository contains the code used by the [BICAlarms-qa](https://us-east-1.c
 Currently, the code will log an error (triggering an alarm to fire) under the following circumstances:
 * When the number of circ trans records in Sierra and Redshift differs for the previous day
 * When there are no circ trans records in Sierra for the previous day
+* When there are no holds updated in Redshift for the previous day
 * When the number of PC reserve records in Envisionware and Redshift differs for the previous day
 * When there are no PC reserve records in Sierra for the previous day
 * When the number of newly created/deleted patron records in Sierra and Redshift differs for any day in the previous week

--- a/alarm_controller.py
+++ b/alarm_controller.py
@@ -89,6 +89,9 @@ class AlarmController:
                     self.yesterday))
 
     def run_holds_alarm(self):
+        if not self.run_added_tests:
+            return
+        
         self.logger.info(
             'Checking that holds were succcessfully updated in Redshift on '
             '{}'.format(self.yesterday))

--- a/alarm_controller.py
+++ b/alarm_controller.py
@@ -10,6 +10,7 @@ from query_helper import (build_envisionware_pc_reserve_query,
                           build_redshift_circ_trans_query,
                           build_redshift_code_counts_query,
                           build_redshift_deleted_patrons_query,
+                          build_redshift_holds_query,
                           build_redshift_itype_null_query,
                           build_redshift_location_null_query,
                           build_redshift_new_patrons_query,
@@ -86,6 +87,20 @@ class AlarmController:
             self.logger.error(
                 'No circ trans records found for all of {}'.format(
                     self.yesterday))
+
+    def run_holds_alarm(self):
+        self.logger.info(
+            'Checking that holds were succcessfully updated in Redshift on '
+            '{}'.format(self.yesterday))
+        redshift_table = 'holds' + self.redshift_suffix
+        redshift_query = build_redshift_holds_query(
+            redshift_table, self.yesterday)
+        redshift_count = self._get_record_count(
+            self.redshift_client, redshift_query)
+
+        if redshift_count == 0:
+            self.logger.error(
+                'No holds updated for all of {}'.format(self.yesterday))
 
     def run_pc_reserve_alarm(self):
         datetime_to_test = self.yesterday_date

--- a/lambda_function.py
+++ b/lambda_function.py
@@ -15,6 +15,7 @@ def lambda_handler(event, context):
     alarm_controller = AlarmController()
     try:
         alarm_controller.run_circ_trans_alarm()
+        alarm_controller.run_holds_alarm()
         alarm_controller.run_pc_reserve_alarm()
         alarm_controller.run_patron_info_alarm()
         alarm_controller.run_sierra_itype_codes_alarms()

--- a/query_helper.py
+++ b/query_helper.py
@@ -54,6 +54,10 @@ _REDSHIFT_CODE_COUNTS_QUERY = (
     'SELECT COUNT({code}), COUNT(DISTINCT {code}) FROM {table} '
     'WHERE deletion_date IS NULL;')
 
+_REDSHIFT_HOLDS_QUERY = (
+    "SELECT COUNT(id) FROM {table} "
+    "WHERE update_date_et = '{date}';")
+
 _REDSHIFT_ITYPE_NULL_QUERY = '''
     SELECT code FROM {table}
     WHERE code != 0
@@ -127,6 +131,10 @@ def build_redshift_pc_reserve_query(table, date):
 
 def build_redshift_code_counts_query(code, table):
     return _REDSHIFT_CODE_COUNTS_QUERY.format(code=code, table=table)
+
+
+def build_redshift_holds_query(table, date):
+    return _REDSHIFT_HOLDS_QUERY.format(table=table, date=date)
 
 
 def build_redshift_itype_null_query(itype_table, date):

--- a/tests/test_alarm_controller.py
+++ b/tests/test_alarm_controller.py
@@ -137,6 +137,24 @@ class TestAlarmController:
             test_instance.run_circ_trans_alarm()
         assert 'No circ trans records found for all of 2023-05-31' \
             in caplog.text
+    
+    def test_run_holds_alarm_no_alarm(
+            self, test_instance, mocker, caplog):
+        mocker.patch('alarm_controller.build_redshift_holds_query')
+        test_instance.redshift_client.execute_query.return_value = ([10],)
+
+        with caplog.at_level(logging.ERROR):
+            test_instance.run_holds_alarm()
+        assert caplog.text == ''
+
+    def test_run_holds_alarm_no_records(
+            self, test_instance, mocker, caplog):
+        mocker.patch('alarm_controller.build_redshift_holds_query')
+        test_instance.redshift_client.execute_query.return_value = ([0],)
+
+        with caplog.at_level(logging.ERROR):
+            test_instance.run_holds_alarm()
+        assert 'No holds updated for all of 2023-05-31' in caplog.text
 
     def test_run_pc_reserve_alarm_no_alarm(
             self, test_instance, mocker, caplog):
@@ -471,7 +489,7 @@ class TestAlarmController:
 
         test_instance.sierra_client.execute_query.return_value = [(10,)]
         test_instance.redshift_client.execute_query.side_effect = [
-            ([10, 10],), (), ()]
+            ([11, 11],), (), ()]
 
         with caplog.at_level(logging.ERROR):
             test_instance.run_sierra_stat_group_codes_alarms()
@@ -507,7 +525,7 @@ class TestAlarmController:
             'alarm_controller.build_redshift_stat_group_location_query')
         test_instance.sierra_client.execute_query.return_value = [(10,)]
         test_instance.redshift_client.execute_query.side_effect = [
-            ([20, 20],), (), ()]
+            ([21, 21],), (), ()]
 
         with caplog.at_level(logging.ERROR):
             test_instance.run_sierra_stat_group_codes_alarms()
@@ -524,7 +542,7 @@ class TestAlarmController:
             'alarm_controller.build_redshift_stat_group_location_query')
         test_instance.sierra_client.execute_query.return_value = [(10,)]
         test_instance.redshift_client.execute_query.side_effect = [
-            ([10, 9],), (), ()]
+            ([11, 10],), (), ()]
 
         with caplog.at_level(logging.ERROR):
             test_instance.run_sierra_stat_group_codes_alarms()
@@ -541,7 +559,7 @@ class TestAlarmController:
             'alarm_controller.build_redshift_stat_group_location_query')
         test_instance.sierra_client.execute_query.return_value = [(10,)]
         test_instance.redshift_client.execute_query.side_effect = [
-            ([10, 10],), ([1], [2]), ()]
+            ([11, 11],), ([1], [2]), ()]
 
         with caplog.at_level(logging.ERROR):
             test_instance.run_sierra_stat_group_codes_alarms()
@@ -557,7 +575,7 @@ class TestAlarmController:
             'alarm_controller.build_redshift_stat_group_location_query')
         test_instance.sierra_client.execute_query.return_value = [(10,)]
         test_instance.redshift_client.execute_query.side_effect = [
-            ([10, 10],), (), ([3], [4])]
+            ([11, 11],), (), ([3], [4])]
 
         with caplog.at_level(logging.ERROR):
             test_instance.run_sierra_stat_group_codes_alarms()


### PR DESCRIPTION
Checks that at least some holds have been added or updated in Redshift for the previous day. As holds are constantly changing, there's no good way to test that the right number have been updated, so this alarm only checks that at least one has updated.