### PR TITLE
Run holds query for today and account for circ trans timezones

### DIFF
--- a/query_helper.py
+++ b/query_helper.py
@@ -1,6 +1,6 @@
 _SIERRA_CIRC_TRANS_QUERY = (
     "SELECT COUNT(id) FROM sierra_view.circ_trans "
-    "WHERE (transaction_gmt AT TIME ZONE 'EST')::DATE = '{date}';")
+    "WHERE (transaction_gmt AT TIME ZONE '{timezone}')::DATE = '{date}';")
 
 _SIERRA_NEW_PATRONS_QUERY = '''
     SELECT (creation_date_gmt AT TIME ZONE 'EST')::DATE, COUNT(id)
@@ -129,8 +129,9 @@ _REDSHIFT_STAT_GROUP_LOCATION_QUERY = '''
             WHERE deletion_date IS NULL);'''
 
 
-def build_sierra_circ_trans_query(date):
-    return _SIERRA_CIRC_TRANS_QUERY.format(date=date)
+def build_sierra_circ_trans_query(date, timezone):
+    return _SIERRA_CIRC_TRANS_QUERY.format(
+        date=date, timezone=timezone)
 
 
 def build_sierra_new_patrons_query(start_date, end_date):


### PR DESCRIPTION
1) Holds poller runs nightly so late that "yesterday"'s  date in Eastern time is actually today's date in UTC. So the most recent date for the data is actually "today" rather than "yesterday".
2) Account for different circ_trans counts in old/new table as a result of different timezones used when querying Sierra. This only recently became a problem because of daylight savings.