### PR TITLE
Add location visits alarms

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ Currently, the code will log an error (triggering an alarm to fire) under the fo
 * When there are no PC reserve records in Sierra for the previous day
 * When the number of newly created/deleted patron records in Sierra and Redshift differs for any day in the previous week
 * When there are no newly created patron records in Sierra for the previous any day in the previous week
-* When there are multiple location visits records with the same combination of fields that should be unique
 * When there are fewer than 10000 new location visits records for the previous day
+* When a given location visits (site id, orbit, increment start) combination does not map to exactly one fresh row
 * When the number of active itype/location/stat group codes in Sierra and Redshift differs
 * When there are duplicate active itype/location/stat group codes in Redshift
 * When there are active itype/location/stat group codes in Redshift without the necessary additional fields populated

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Currently, the code will log an error (triggering an alarm to fire) under the fo
 * When there are no PC reserve records in Sierra for the previous day
 * When the number of newly created/deleted patron records in Sierra and Redshift differs for any day in the previous week
 * When there are no newly created patron records in Sierra for the previous any day in the previous week
+* When there are multiple location visits records with the same combination of fields that should be unique
+* When there are fewer than 10000 new location visits records for the previous day
 * When the number of active itype/location/stat group codes in Sierra and Redshift differs
 * When there are duplicate active itype/location/stat group codes in Redshift
 * When there are active itype/location/stat group codes in Redshift without the necessary additional fields populated

--- a/alarm_controller.py
+++ b/alarm_controller.py
@@ -18,6 +18,7 @@ from query_helper import (build_envisionware_pc_reserve_query,
                           build_redshift_location_null_query,
                           build_redshift_location_visits_count_query,
                           build_redshift_location_visits_duplicate_query,
+                          build_redshift_location_visits_stale_query,
                           build_redshift_new_patrons_query,
                           build_redshift_pc_reserve_query,
                           build_redshift_stat_group_location_query,
@@ -237,30 +238,41 @@ class AlarmController:
 
         self.logger.info('\nLOCATION VISITS\n')
         redshift_table = 'location_visits' + self.redshift_suffix
+        stale_start_date = (self.yesterday_date -
+                            timedelta(days=30)).isoformat()
         redshift_count_query = build_redshift_location_visits_count_query(
             redshift_table, self.yesterday)
         redshift_duplicate_query = \
             build_redshift_location_visits_duplicate_query(
                 redshift_table, self.yesterday)
+        redshift_stale_query = build_redshift_location_visits_stale_query(
+            redshift_table, stale_start_date)
 
         self.redshift_client.connect()
         redshift_count = int(self.redshift_client.execute_query(
             redshift_count_query)[0][0])
         redshift_duplicates = self.redshift_client.execute_query(
             redshift_duplicate_query)
+        redshift_stale_rows = self.redshift_client.execute_query(
+            redshift_stale_query)
         self.redshift_client.close_connection()
 
-        if len(redshift_duplicates) > 0:
-            self.logger.error(
-                'The following (shoppertrak_site_id, orbit, increment_start, '
-                'is_healthy_orbit) combinations erroneously apply to more '
-                'than one row: {}'.format(redshift_duplicates))
         if redshift_count < 10000:
             self.logger.error((
                 'Found only {redshift_count} {redshift_table} rows for all of '
                 '{date}').format(redshift_count=redshift_count,
                                  redshift_table=redshift_table,
                                  date=self.yesterday))
+        if len(redshift_duplicates) > 0:
+            self.logger.error(
+                'The following (shoppertrak_site_id, orbit, increment_start) '
+                'combinations contain more than one fresh row: {}'.format(
+                    redshift_duplicates))
+        if len(redshift_stale_rows) > 0:
+            self.logger.error(
+                'The following (shoppertrak_site_id, orbit, increment_start) '
+                'combinations are marked as stale and have not been replaced '
+                'with a fresh row: {}'.format(redshift_stale_rows))
 
     def run_sierra_itype_codes_alarms(self):
         self.logger.info('\nITYPE CODES\n')

--- a/lambda_function.py
+++ b/lambda_function.py
@@ -19,6 +19,7 @@ def lambda_handler(event, context):
         alarm_controller.run_holds_alarms()
         alarm_controller.run_pc_reserve_alarms()
         alarm_controller.run_patron_info_alarms()
+        alarm_controller.run_location_visits_alarms()
         alarm_controller.run_sierra_itype_codes_alarms()
         alarm_controller.run_sierra_location_codes_alarms()
         alarm_controller.run_sierra_stat_group_codes_alarms()

--- a/query_helper.py
+++ b/query_helper.py
@@ -102,6 +102,16 @@ _REDSHIFT_HOLDS_NULL_QUERY = '''
             )
         );'''
 
+_REDSHIFT_LOCATION_VISITS_COUNT_QUERY = (
+    "SELECT COUNT(id) FROM {table} WHERE increment_start::DATE = '{date}';")
+
+_REDSHIFT_LOCATION_VISITS_DUPLICATE_QUERY = '''
+    SELECT shoppertrak_site_id, orbit, increment_start, is_healthy_orbit
+    FROM {table}
+    WHERE increment_start::DATE = '{date}'
+    GROUP BY shoppertrak_site_id, orbit, increment_start, is_healthy_orbit
+    HAVING COUNT(*) > 1;'''
+
 _REDSHIFT_ITYPE_NULL_QUERY = '''
     SELECT code FROM {table}
     WHERE code != 0
@@ -192,6 +202,16 @@ def build_redshift_holds_modified_query(table):
 
 def build_redshift_holds_null_query(table, date):
     return _REDSHIFT_HOLDS_NULL_QUERY.format(table=table, date=date)
+
+
+def build_redshift_location_visits_count_query(table, date):
+    return _REDSHIFT_LOCATION_VISITS_COUNT_QUERY.format(
+        table=table, date=date)
+
+
+def build_redshift_location_visits_duplicate_query(table, date):
+    return _REDSHIFT_LOCATION_VISITS_DUPLICATE_QUERY.format(
+        table=table, date=date)
 
 
 def build_redshift_itype_null_query(itype_table, date):

--- a/tests/test_alarm_controller.py
+++ b/tests/test_alarm_controller.py
@@ -418,8 +418,11 @@ class TestAlarmController:
         mock_redshift_duplicate_query = mocker.patch(
             'alarm_controller.build_redshift_location_visits_duplicate_query',
             return_value='redshift duplicate query')
+        mock_redshift_stale_query = mocker.patch(
+            'alarm_controller.build_redshift_location_visits_stale_query',
+            return_value='redshift stale query')
         test_instance.redshift_client.execute_query.side_effect = [
-            ([11000],), ()]
+            ([11000],), (), ()]
 
         with caplog.at_level(logging.ERROR):
             test_instance.run_location_visits_alarms()
@@ -430,28 +433,13 @@ class TestAlarmController:
             'location_visits_test_redshift_db', '2023-05-31')
         mock_redshift_duplicate_query.assert_called_once_with(
             'location_visits_test_redshift_db', '2023-05-31')
+        mock_redshift_stale_query.assert_called_once_with(
+            'location_visits_test_redshift_db', '2023-05-01')
         test_instance.redshift_client.execute_query.assert_has_calls([
             mocker.call('redshift count query'),
-            mocker.call('redshift duplicate query')])
+            mocker.call('redshift duplicate query'),
+            mocker.call('redshift stale query')])
         test_instance.redshift_client.close_connection.assert_called_once()
-
-    def test_run_location_visits_alarms_duplicate_records(
-            self, test_instance, mocker, caplog):
-        mocker.patch(
-            'alarm_controller.build_redshift_location_visits_count_query')
-        mocker.patch(
-            'alarm_controller.build_redshift_location_visits_duplicate_query')
-        test_instance.redshift_client.execute_query.side_effect = [
-            ([11000],), (['lib a', 1, datetime(2023, 5, 31, 9, 0, 0), True],
-                         ['lib b', 2, datetime(2023, 5, 31, 9, 15, 0), False])]
-
-        with caplog.at_level(logging.ERROR):
-            test_instance.run_location_visits_alarms()
-        assert ('The following (shoppertrak_site_id, orbit, increment_start, '
-                'is_healthy_orbit) combinations erroneously apply to more '
-                "than one row: (['lib a', 1, FakeDatetime(2023, 5, 31, 9, 0), "
-                "True], ['lib b', 2, FakeDatetime(2023, 5, 31, 9, 15), "
-                "False])") in caplog.text
 
     def test_run_location_visits_alarms_no_records(
             self, test_instance, mocker, caplog):
@@ -459,13 +447,58 @@ class TestAlarmController:
             'alarm_controller.build_redshift_location_visits_count_query')
         mocker.patch(
             'alarm_controller.build_redshift_location_visits_duplicate_query')
+        mocker.patch(
+            'alarm_controller.build_redshift_location_visits_stale_query')
         test_instance.redshift_client.execute_query.side_effect = [
-            ([10],), ()]
+            ([10],), (), ()]
 
         with caplog.at_level(logging.ERROR):
             test_instance.run_location_visits_alarms()
         assert ('Found only 10 location_visits_test_redshift_db rows for all '
                 'of 2023-05-31') in caplog.text
+
+    def test_run_location_visits_alarms_duplicate_records(
+            self, test_instance, mocker, caplog):
+        mocker.patch(
+            'alarm_controller.build_redshift_location_visits_count_query')
+        mocker.patch(
+            'alarm_controller.build_redshift_location_visits_duplicate_query')
+        mocker.patch(
+            'alarm_controller.build_redshift_location_visits_stale_query')
+        test_instance.redshift_client.execute_query.side_effect = [
+            ([11000],),
+            (['aa', 1, datetime(2023, 5, 31, 9, 0, 0)],
+             ['bb', 2, datetime(2023, 5, 31, 9, 15, 0)]),
+            ()]
+
+        with caplog.at_level(logging.ERROR):
+            test_instance.run_location_visits_alarms()
+        assert ('The following (shoppertrak_site_id, orbit, increment_start) '
+                "combinations contain more than one fresh row: (['aa', 1, "
+                "FakeDatetime(2023, 5, 31, 9, 0)], ['bb', 2, "
+                'FakeDatetime(2023, 5, 31, 9, 15)])') in caplog.text
+
+    def test_run_location_visits_alarms_stale_records(
+            self, test_instance, mocker, caplog):
+        mocker.patch(
+            'alarm_controller.build_redshift_location_visits_count_query')
+        mocker.patch(
+            'alarm_controller.build_redshift_location_visits_duplicate_query')
+        mocker.patch(
+            'alarm_controller.build_redshift_location_visits_stale_query')
+        test_instance.redshift_client.execute_query.side_effect = [
+            ([11000],),
+            (),
+            (['aa', 1, datetime(2023, 5, 31, 9, 0, 0)],
+             ['bb', 2, datetime(2023, 5, 31, 9, 15, 0)])]
+
+        with caplog.at_level(logging.ERROR):
+            test_instance.run_location_visits_alarms()
+        assert ('The following (shoppertrak_site_id, orbit, increment_start) '
+                'combinations are marked as stale and have not been replaced '
+                "with a fresh row: (['aa', 1, FakeDatetime(2023, 5, 31, 9, "
+                "0)], ['bb', 2, FakeDatetime(2023, 5, 31, 9, 15)])"
+                ) in caplog.text
 
     def test_run_sierra_itype_codes_alarms_no_alarms(
             self, test_instance, mocker, caplog):

--- a/tests/test_lambda_function.py
+++ b/tests/test_lambda_function.py
@@ -36,6 +36,7 @@ class TestLambdaFunction:
         mock_alarm_controller.run_holds_alarms.assert_called_once()
         mock_alarm_controller.run_pc_reserve_alarms.assert_called_once()
         mock_alarm_controller.run_patron_info_alarms.assert_called_once()
+        mock_alarm_controller.run_location_visits_alarms.assert_called_once()
         mock_alarm_controller.run_sierra_itype_codes_alarms.assert_called_once()  # noqa: E501
         mock_alarm_controller.run_sierra_location_codes_alarms.assert_called_once()  # noqa: E501
         mock_alarm_controller.run_sierra_stat_group_codes_alarms.assert_called_once()  # noqa: E501
@@ -51,6 +52,7 @@ class TestLambdaFunction:
         mock_alarm_controller.run_holds_alarms.assert_called_once()
         mock_alarm_controller.run_pc_reserve_alarms.assert_called_once()
         mock_alarm_controller.run_patron_info_alarms.assert_not_called()
+        mock_alarm_controller.run_run_location_visits_alarms.assert_not_called()  # noqa: E501
         mock_alarm_controller.run_sierra_itype_codes_alarms.assert_not_called()  # noqa: E501
         mock_alarm_controller.run_sierra_location_codes_alarms.assert_not_called()  # noqa: E501
         mock_alarm_controller.run_sierra_stat_group_codes_alarms.assert_not_called()  # noqa: E501


### PR DESCRIPTION
1. When there are fewer than 10k records for the previous day (there should be about 11k per day)
2. When one (shoppertrak_site_id, orbit, increment_start, is_healthy_orbit) combination applies to multiple rows -- i.e. when there are duplicate records