### PR TITLE
Remove Redshift circ_trans alarms

### DIFF
--- a/alarm_controller.py
+++ b/alarm_controller.py
@@ -72,39 +72,32 @@ class AlarmController:
 
     def run_circ_trans_alarms(self):
         self.logger.info('\nCIRC TRANS\n')
-        sierra_timezones = ('EST', 'America/New_York')
-        redshift_tables = (
-            ['circ_trans'], ['patron_circ_trans', 'item_circ_trans'])
-        redshift_date_fields = (['transaction_et'], [
-            'transaction_et',
-            'CONVERT_TIMEZONE(\'America/New_York\', transaction_timestamp)::DATE'])  # noqa: E501
+        sierra_query = build_sierra_circ_trans_query(self.yesterday)
+        sierra_count = self._get_record_count(self.sierra_client, sierra_query)
+        if sierra_count == 0 and self.run_added_tests:
+            self.logger.error(
+                'No Sierra circ trans records found for all of {}'.format(
+                    self.yesterday))
 
-        for i in range(len(sierra_timezones)):
-            sierra_query = build_sierra_circ_trans_query(
-                self.yesterday, sierra_timezones[i])
-            sierra_count = self._get_record_count(
-                self.sierra_client, sierra_query)
-            for j in range(len(redshift_tables[i])):
-                redshift_table = redshift_tables[i][j] + self.redshift_suffix
-                date_field = redshift_date_fields[i][j]
-                redshift_query = build_redshift_circ_trans_query(
-                    redshift_table, date_field, self.yesterday)
-                redshift_count = self._get_record_count(
-                    self.redshift_client, redshift_query)
+        redshift_parameters = [
+            ('patron_circ_trans', 'transaction_et'),
+            ('item_circ_trans',
+             'CONVERT_TIMEZONE(\'America/New_York\', transaction_timestamp)::DATE')]  # noqa: E501
+        for table, date_field in redshift_parameters:
+            redshift_table = table + self.redshift_suffix
+            redshift_query = build_redshift_circ_trans_query(
+                redshift_table, date_field, self.yesterday)
+            redshift_count = self._get_record_count(
+                self.redshift_client, redshift_query)
 
-                if sierra_count != redshift_count:
-                    self.logger.error((
-                        'Number of Sierra circ trans records does not match '
-                        'number of Redshift {redshift_table} records: '
-                        '{sierra_count} Sierra records and {redshift_count} '
-                        'Redshift records').format(
-                            redshift_table=redshift_table,
-                            sierra_count=sierra_count,
-                            redshift_count=redshift_count))
-            if sierra_count == 0 and self.run_added_tests:
-                self.logger.error(
-                    'No Sierra circ trans records found for all of {}'.format(
-                        self.yesterday))
+            if sierra_count != redshift_count:
+                self.logger.error((
+                    'Number of Sierra circ trans records does not match '
+                    'number of Redshift {redshift_table} records: '
+                    '{sierra_count} Sierra records and {redshift_count} '
+                    'Redshift records').format(redshift_table=redshift_table,
+                                               sierra_count=sierra_count,
+                                               redshift_count=redshift_count))
 
     def run_holds_alarms(self):
         self.logger.info('\nHOLDS\n')

--- a/query_helper.py
+++ b/query_helper.py
@@ -1,6 +1,7 @@
 _SIERRA_CIRC_TRANS_QUERY = (
     "SELECT COUNT(id) FROM sierra_view.circ_trans "
-    "WHERE (transaction_gmt AT TIME ZONE '{timezone}')::DATE = '{date}';")
+    "WHERE (transaction_gmt AT TIME ZONE 'America/New_York')::DATE = '{date}';"
+)
 
 _SIERRA_NEW_PATRONS_QUERY = '''
     SELECT (creation_date_gmt AT TIME ZONE 'EST')::DATE, COUNT(id)
@@ -29,7 +30,7 @@ _ENVISIONWARE_PC_RESERVE_QUERY = (
     "WHERE DATE(pcrDateTime) = '{date}';")
 
 _REDSHIFT_CIRC_TRANS_QUERY = (
-    "SELECT COUNT(*) FROM {table} "
+    "SELECT COUNT(id) FROM {table} "
     "WHERE {date_field} = '{date}';")
 
 _REDSHIFT_NEW_PATRONS_QUERY = '''
@@ -155,9 +156,8 @@ _REDSHIFT_STAT_GROUP_LOCATION_QUERY = '''
             WHERE deletion_date IS NULL);'''
 
 
-def build_sierra_circ_trans_query(date, timezone):
-    return _SIERRA_CIRC_TRANS_QUERY.format(
-        date=date, timezone=timezone)
+def build_sierra_circ_trans_query(date):
+    return _SIERRA_CIRC_TRANS_QUERY.format(date=date)
 
 
 def build_sierra_new_patrons_query(start_date, end_date):

--- a/tests/test_alarm_controller.py
+++ b/tests/test_alarm_controller.py
@@ -89,12 +89,10 @@ class TestAlarmController:
             self, test_instance, mocker, caplog):
         mock_sierra_query = mocker.patch(
             'alarm_controller.build_sierra_circ_trans_query',
-            side_effect=['sierra circ trans EST query',
-                         'sierra circ trans New York query'])
+            return_value='sierra circ trans query')
         mock_redshift_query = mocker.patch(
             'alarm_controller.build_redshift_circ_trans_query',
-            side_effect=['redshift circ trans query',
-                         'redshift patron circ trans query',
+            side_effect=['redshift patron circ trans query',
                          'redshift item circ trans query'])
         test_instance.sierra_client.execute_query.return_value = [(10,)]
         test_instance.redshift_client.execute_query.return_value = ([10],)
@@ -103,43 +101,34 @@ class TestAlarmController:
             test_instance.run_circ_trans_alarms()
         assert caplog.text == ''
 
-        assert test_instance.sierra_client.connect.call_count == 2
-        mock_sierra_query.assert_has_calls([
-            mocker.call('2023-05-31', 'EST'),
-            mocker.call('2023-05-31', 'America/New_York')])
-        test_instance.sierra_client.execute_query.assert_has_calls([
-            mocker.call('sierra circ trans EST query'),
-            mocker.call('sierra circ trans New York query')])
-        assert test_instance.sierra_client.close_connection.call_count == 2
+        test_instance.sierra_client.connect.assert_called_once()
+        mock_sierra_query.assert_called_once_with('2023-05-31')
+        test_instance.sierra_client.execute_query.assert_called_once_with(
+            'sierra circ trans query')
+        test_instance.sierra_client.close_connection.assert_called_once()
 
-        assert test_instance.redshift_client.connect.call_count == 3
+        assert test_instance.redshift_client.connect.call_count == 2
         mock_redshift_query.assert_has_calls([
-            mocker.call('circ_trans_test_redshift_db', 'transaction_et', '2023-05-31'),  # noqa: E501
             mocker.call('patron_circ_trans_test_redshift_db', 'transaction_et',
                         '2023-05-31'),
             mocker.call('item_circ_trans_test_redshift_db',
                         'CONVERT_TIMEZONE(\'America/New_York\', transaction_timestamp)::DATE',  # noqa: E501
                         '2023-05-31')])
         test_instance.redshift_client.execute_query.assert_has_calls([
-            mocker.call('redshift circ trans query'),
             mocker.call('redshift patron circ trans query'),
             mocker.call('redshift item circ trans query')])
-        assert test_instance.redshift_client.close_connection.call_count == 3
+        assert test_instance.redshift_client.close_connection.call_count == 2
 
     def test_run_circ_trans_alarms_unequal_counts(
             self, test_instance, mocker, caplog):
         mocker.patch('alarm_controller.build_sierra_circ_trans_query')
         mocker.patch('alarm_controller.build_redshift_circ_trans_query')
-        test_instance.sierra_client.execute_query.side_effect = [
-            [(10,)], [(20,)]]
+        test_instance.sierra_client.execute_query.return_value = [(20,)]
         test_instance.redshift_client.execute_query.side_effect = [
-            ([20],), ([15],), ([10],)]
+            ([15],), ([10],)]
 
         with caplog.at_level(logging.ERROR):
             test_instance.run_circ_trans_alarms()
-        assert ('Number of Sierra circ trans records does not match number of '
-                'Redshift circ_trans_test_redshift_db records: 10 Sierra '
-                'records and 20 Redshift records') in caplog.text
         assert ('Number of Sierra circ trans records does not match number of '
                 'Redshift patron_circ_trans_test_redshift_db records: 20 '
                 'Sierra records and 15 Redshift records') in caplog.text


### PR DESCRIPTION
The circ_trans table has been fully replaced by the item_circ_trans and patron_circ_trans tables