### PR TITLE
Remove tests for defunct circ_trans Redshift table

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,4 +18,4 @@ test:
 	pytest tests -W ignore::DeprecationWarning
 
 lint:
-	flake8 --exclude *env,package
+	black ./ --check --exclude="(env/)|(tests/)"

--- a/helpers/query_helper.py
+++ b/helpers/query_helper.py
@@ -1,6 +1,6 @@
 _SIERRA_CIRC_TRANS_QUERY = (
     "SELECT COUNT(id) FROM sierra_view.circ_trans "
-    "WHERE (transaction_gmt AT TIME ZONE '{timezone}')::DATE = '{date}';"
+    "WHERE (transaction_gmt AT TIME ZONE 'America/New_York')::DATE = '{date}';"
 )
 
 _SIERRA_NEW_PATRONS_QUERY = """

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-nypl-py-utils[mysql-client]==1.1.2
+nypl-py-utils[mysql-client]==1.1.5
 redshift-connector

--- a/tests/alarms/models/test_circ_trans_alarms.py
+++ b/tests/alarms/models/test_circ_trans_alarms.py
@@ -24,15 +24,11 @@ class TestCircTransAlarms:
     def test_run_checks_no_alarm(self, test_instance, mocker, caplog):
         mock_sierra_query = mocker.patch(
             "alarms.models.circ_trans_alarms.build_sierra_circ_trans_query",
-            side_effect=[
-                "sierra circ trans EST query",
-                "sierra circ trans New York query",
-            ],
+            return_value="sierra circ trans query",
         )
         mock_redshift_query = mocker.patch(
             "alarms.models.circ_trans_alarms.build_redshift_circ_trans_query",
             side_effect=[
-                "redshift circ trans query",
                 "redshift patron circ trans query",
                 "redshift item circ trans query",
             ],
@@ -44,63 +40,43 @@ class TestCircTransAlarms:
             test_instance.run_checks()
         assert caplog.text == ""
 
-        assert test_instance.sierra_client.connect.call_count == 2
-        mock_sierra_query.assert_has_calls(
-            [
-                mocker.call("2023-05-31", "EST"),
-                mocker.call("2023-05-31", "America/New_York"),
-            ]
+        test_instance.sierra_client.connect.assert_called_once()
+        mock_sierra_query.assert_called_once_with("2023-05-31")
+        test_instance.sierra_client.execute_query.assert_called_once_with(
+            "sierra circ trans query"
         )
-        test_instance.sierra_client.execute_query.assert_has_calls(
-            [
-                mocker.call("sierra circ trans EST query"),
-                mocker.call("sierra circ trans New York query"),
-            ]
-        )
-        assert test_instance.sierra_client.close_connection.call_count == 2
+        test_instance.sierra_client.close_connection.assert_called_once()
 
-        assert test_instance.redshift_client.connect.call_count == 3
+        assert test_instance.redshift_client.connect.call_count == 2
         mock_redshift_query.assert_has_calls(
             [
-                mocker.call(
-                    "circ_trans_test_redshift_db", "transaction_et", "2023-05-31"
-                ),  # noqa: E501
                 mocker.call(
                     "patron_circ_trans_test_redshift_db", "transaction_et", "2023-05-31"
                 ),
                 mocker.call(
                     "item_circ_trans_test_redshift_db",
-                    "CONVERT_TIMEZONE('America/New_York', transaction_timestamp)::DATE",  # noqa: E501
+                    "CONVERT_TIMEZONE('America/New_York', transaction_timestamp)::DATE",
                     "2023-05-31",
                 ),
             ]
         )
         test_instance.redshift_client.execute_query.assert_has_calls(
             [
-                mocker.call("redshift circ trans query"),
                 mocker.call("redshift patron circ trans query"),
                 mocker.call("redshift item circ trans query"),
             ]
         )
-        assert test_instance.redshift_client.close_connection.call_count == 3
+        assert test_instance.redshift_client.close_connection.call_count == 2
 
     def test_run_checks_unequal_counts(self, test_instance, mocker, caplog):
         mocker.patch("alarms.models.circ_trans_alarms.build_sierra_circ_trans_query")
         mocker.patch("alarms.models.circ_trans_alarms.build_redshift_circ_trans_query")
-        test_instance.sierra_client.execute_query.side_effect = [[(10,)], [(20,)]]
-        test_instance.redshift_client.execute_query.side_effect = [
-            ([20],),
-            ([15],),
-            ([10],),
-        ]
+        test_instance.sierra_client.execute_query.return_value = [(20,)]
+        test_instance.redshift_client.execute_query.side_effect = [([15],), ([10],)]
 
         with caplog.at_level(logging.ERROR):
             test_instance.run_checks()
-        assert (
-            "Number of Sierra circ trans records does not match number "
-            "of Redshift circ_trans_test_redshift_db records: 10 "
-            "Sierra circ trans records and 20 Redshift records"
-        ) in caplog.text
+
         assert (
             "Number of Sierra circ trans records does not match number of "
             "Redshift patron_circ_trans_test_redshift_db records: 20 "
@@ -120,4 +96,5 @@ class TestCircTransAlarms:
 
         with caplog.at_level(logging.ERROR):
             test_instance.run_checks()
+
         assert "No Sierra circ trans records found for all of 2023-05-31" in caplog.text


### PR DESCRIPTION
Also:

- Updated Makefile to use `black` linter instead of `flake8`
- Updated nypl-py-utils package to newest version