### PR TITLE
Handle any OverDrive exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2024-11-12
+### Fixed
+- Gracefully handle any exception thrown by the OverDrive web scraper
+
 ## 2024-09-19
 ### Added
 - Refactor code to run in an ECS cluster rather than as a Lambda

--- a/alarms/models/overdrive_checkouts_alarms.py
+++ b/alarms/models/overdrive_checkouts_alarms.py
@@ -3,7 +3,7 @@ from helpers.alarm_helper import (
     check_redshift_mismatch_alarm,
     check_no_records_found_alarm,
 )
-from helpers.overdrive_web_scraper import OverDriveWebScraper, OverDriveWebScraperError
+from helpers.overdrive_web_scraper import OverDriveWebScraper
 from helpers.query_helper import build_redshift_overdrive_query
 from nypl_py_utils.functions.log_helper import create_log
 
@@ -20,7 +20,7 @@ class OverDriveCheckoutsAlarms(Alarm):
         self.logger.info("\nOVERDRIVE CHECKOUTS\n")
         try:
             overdrive_count = self.overdrive_client.get_count(self.yesterday)
-        except OverDriveWebScraperError:
+        except:
             self.logger.error("Failed to scrape OverDrive Marketplace")
             return
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-nypl-py-utils[mysql-client,postgresql-client,redshift-client,config-helper]==1.3.2
+nypl-py-utils[mysql-client,postgresql-client,redshift-client,config-helper]==1.4.0
 selenium>=4.10.0


### PR DESCRIPTION
Even if an unknown / unexpected error is thrown by the web scraper, do not prevent the other alarms from running. Also updated nypl-py-utils version