### PR TITLE
Add EZproxy alarms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2025-08-25
+### Added
+- Add EZproxy alarms
+
+### Fixed
+- Update hold alarms to check for previously deleted holds using timestamps rather than only dates
+
 ## 2025-06-27
 ### Added
 - Update OverDrive alerting to account for different download types

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Currently, the code will log an error (triggering an alarm to fire) under the fo
 * When a single Sierra branch code maps to multiple Drupal branch codes
 * When a Drupal branch code in location_hours does not contain a mapping to a Sierra branch code
 * When a Sierra branch code with a mapping to a Drupal branch code does not appear in location_hours
+* When there are fewer than 1000 EZproxy session rows for the previous day
+* When a given EZproxy (session id, patron id, domain) combination from the previous day corresponds to multiple rows
 * When there are fewer than 10000 new location visits records for the previous day
 * When a given location visits (site id, orbit, increment start) combination from the previous day contains multiple fresh rows
 * When a given location visits (site id, orbit, increment start) combination from the previous thirty days contains only stale rows

--- a/alarm_controller.py
+++ b/alarm_controller.py
@@ -3,6 +3,7 @@ import os
 from alarms.models.branch_codes_map_alarms import BranchCodesMapAlarms
 from alarms.models.circ_trans_alarms import CircTransAlarms
 from alarms.models.daily_location_visits_alarms import DailyLocationVisitsAlarms
+from alarms.models.ezproxy_alarms import EZproxyAlarms
 from alarms.models.granular_location_visits_alarms import GranularLocationVisitsAlarms
 from alarms.models.holds_alarms import HoldsAlarms
 from alarms.models.overdrive_checkouts_alarms import OverDriveCheckoutsAlarms
@@ -66,6 +67,7 @@ class AlarmController:
             CircTransAlarms(self.redshift_client, self.sierra_client),
             GranularLocationVisitsAlarms(self.redshift_client),
             DailyLocationVisitsAlarms(self.redshift_client),
+            EZproxyAlarms(self.redshift_client),
             HoldsAlarms(self.redshift_client),
             OverDriveCheckoutsAlarms(self.redshift_client, self.overdrive_credentials),
             PatronInfoAlarms(self.redshift_client, self.sierra_client),

--- a/alarms/models/ezproxy_alarms.py
+++ b/alarms/models/ezproxy_alarms.py
@@ -1,0 +1,46 @@
+from alarms.alarm import Alarm
+from helpers.query_helper import (
+    build_redshift_ezproxy_count_query,
+    build_redshift_ezproxy_duplicate_query,
+)
+from nypl_py_utils.functions.log_helper import create_log
+
+
+class EZproxyAlarms(Alarm):
+    def __init__(self, redshift_client):
+        super().__init__(redshift_client)
+        self.logger = create_log("ezproxy_alarms")
+
+    def run_checks(self):
+        self.logger.info("EZPROXY")
+
+        redshift_table = "ezproxy_sessions" + self.redshift_suffix
+        count_query = build_redshift_ezproxy_count_query(redshift_table, self.yesterday)
+        duplicate_query = build_redshift_ezproxy_duplicate_query(
+            redshift_table, self.yesterday
+        )
+
+        self.redshift_client.connect()
+        count = int(self.redshift_client.execute_query(count_query)[0][0])
+        duplicates = self.redshift_client.execute_query(duplicate_query)
+        self.redshift_client.close_connection()
+
+        self.check_less_than_one_thousand_alarm(count, redshift_table)
+        self.check_duplicates_alarm(duplicates)
+
+    def check_less_than_one_thousand_alarm(self, count, redshift_table):
+        if count < 1000:
+            self.logger.error(
+                "Found only {count} {redshift_table} rows for all of {date}".format(
+                    count=count, redshift_table=redshift_table, date=self.yesterday
+                )
+            )
+
+    def check_duplicates_alarm(self, duplicates):
+        if len(duplicates) > 0:
+            self.logger.error(
+                "The following (session_id, patron_id, domain) combinations correspond "
+                "to more than one row on {date}: {rows}".format(
+                    date=self.yesterday, rows=duplicates
+                )
+            )

--- a/tests/alarms/models/test_ezproxy_alarms.py
+++ b/tests/alarms/models/test_ezproxy_alarms.py
@@ -1,0 +1,83 @@
+import logging
+import pytest
+
+from alarms.models.ezproxy_alarms import EZproxyAlarms
+from datetime import date
+
+
+class TestEZproxyAlarms:
+    @pytest.fixture
+    def test_instance(self, mocker):
+        return EZproxyAlarms(mocker.MagicMock())
+
+    def test_init(self, mocker):
+        ezproxy_alarms = EZproxyAlarms(mocker.MagicMock())
+        assert ezproxy_alarms.redshift_suffix == "_test_redshift_db"
+        assert ezproxy_alarms.run_added_tests
+        assert ezproxy_alarms.yesterday_date == date(2023, 5, 31)
+        assert ezproxy_alarms.yesterday == "2023-05-31"
+
+    def test_run_checks_no_alarm(self, test_instance, mocker, caplog):
+        mock_redshift_count_query = mocker.patch(
+            "alarms.models.ezproxy_alarms.build_redshift_ezproxy_count_query",
+            return_value="redshift count query",
+        )
+        mock_redshift_duplicate_query = mocker.patch(
+            "alarms.models.ezproxy_alarms.build_redshift_ezproxy_duplicate_query",
+            return_value="redshift duplicate query",
+        )
+        test_instance.redshift_client.execute_query.side_effect = [([11000],), ()]
+
+        with caplog.at_level(logging.ERROR):
+            test_instance.run_checks()
+        assert caplog.text == ""
+
+        test_instance.redshift_client.connect.assert_called_once()
+        mock_redshift_count_query.assert_called_once_with(
+            "ezproxy_sessions_test_redshift_db", "2023-05-31"
+        )
+        mock_redshift_duplicate_query.assert_called_once_with(
+            "ezproxy_sessions_test_redshift_db", "2023-05-31"
+        )
+        test_instance.redshift_client.execute_query.assert_has_calls(
+            [
+                mocker.call("redshift count query"),
+                mocker.call("redshift duplicate query"),
+            ]
+        )
+        test_instance.redshift_client.close_connection.assert_called_once()
+
+    def test_run_checks_no_records_alarm(self, test_instance, mocker, caplog):
+        mocker.patch("alarms.models.ezproxy_alarms.build_redshift_ezproxy_count_query")
+        mocker.patch(
+            "alarms.models.ezproxy_alarms.build_redshift_ezproxy_duplicate_query"
+        )
+        test_instance.redshift_client.execute_query.side_effect = [([100],), ()]
+
+        with caplog.at_level(logging.ERROR):
+            test_instance.run_checks()
+        assert (
+            "Found only 100 ezproxy_sessions_test_redshift_db rows for all of "
+            "2023-05-31"
+        ) in caplog.text
+
+    def test_run_checks_duplicate_records_alarm(self, test_instance, mocker, caplog):
+        mocker.patch("alarms.models.ezproxy_alarms.build_redshift_ezproxy_count_query")
+        mocker.patch(
+            "alarms.models.ezproxy_alarms.build_redshift_ezproxy_duplicate_query"
+        )
+        test_instance.redshift_client.execute_query.side_effect = [
+            ([1100],),
+            (
+                ["sessiona", "patrona", "domaina"],
+                ["sessionb", "patronb", "domainb"],
+            ),
+        ]
+
+        with caplog.at_level(logging.ERROR):
+            test_instance.run_checks()
+        assert (
+            "The following (session_id, patron_id, domain) combinations correspond to "
+            "more than one row on 2023-05-31: (['sessiona', 'patrona', 'domaina'], "
+            "['sessionb', 'patronb', 'domainb'])"
+        ) in caplog.text

--- a/tests/alarms/models/test_holds_alarms.py
+++ b/tests/alarms/models/test_holds_alarms.py
@@ -21,7 +21,7 @@ class TestHoldsAlarms:
 
     def test_run_checks_no_alarm(self, test_instance, mocker, caplog):
         mock_count_query = mocker.patch(
-            "alarms.models.holds_alarms.build_redshift_holds_query",
+            "alarms.models.holds_alarms.build_redshift_holds_count_query",
             return_value="count query",
         )
         mock_deleted_query = mocker.patch(
@@ -77,7 +77,7 @@ class TestHoldsAlarms:
         mocker.patch("alarms.models.holds_alarms.build_redshift_holds_deleted_query")
         mocker.patch("alarms.models.holds_alarms.build_redshift_holds_modified_query")
         mocker.patch("alarms.models.holds_alarms.build_redshift_holds_null_query")
-        mocker.patch("alarms.models.holds_alarms.build_redshift_holds_query")
+        mocker.patch("alarms.models.holds_alarms.build_redshift_holds_count_query")
         test_instance.redshift_client.execute_query.side_effect = [
             ([0],),
             ([10],),
@@ -99,7 +99,7 @@ class TestHoldsAlarms:
         mocker.patch("alarms.models.holds_alarms.build_redshift_holds_deleted_query")
         mocker.patch("alarms.models.holds_alarms.build_redshift_holds_modified_query")
         mocker.patch("alarms.models.holds_alarms.build_redshift_holds_null_query")
-        mocker.patch("alarms.models.holds_alarms.build_redshift_holds_query")
+        mocker.patch("alarms.models.holds_alarms.build_redshift_holds_count_query")
         test_instance.redshift_client.execute_query.side_effect = [
             ([10],),
             ([0],),
@@ -119,7 +119,7 @@ class TestHoldsAlarms:
         mocker.patch("alarms.models.holds_alarms.build_redshift_holds_deleted_query")
         mocker.patch("alarms.models.holds_alarms.build_redshift_holds_modified_query")
         mocker.patch("alarms.models.holds_alarms.build_redshift_holds_null_query")
-        mocker.patch("alarms.models.holds_alarms.build_redshift_holds_query")
+        mocker.patch("alarms.models.holds_alarms.build_redshift_holds_count_query")
         test_instance.redshift_client.execute_query.side_effect = [
             ([10],),
             ([10],),
@@ -146,7 +146,7 @@ class TestHoldsAlarms:
         mocker.patch("alarms.models.holds_alarms.build_redshift_holds_deleted_query")
         mocker.patch("alarms.models.holds_alarms.build_redshift_holds_modified_query")
         mocker.patch("alarms.models.holds_alarms.build_redshift_holds_null_query")
-        mocker.patch("alarms.models.holds_alarms.build_redshift_holds_query")
+        mocker.patch("alarms.models.holds_alarms.build_redshift_holds_count_query")
         test_instance.redshift_client.execute_query.side_effect = [
             ([10],),
             ([10],),
@@ -172,7 +172,7 @@ class TestHoldsAlarms:
         mocker.patch("alarms.models.holds_alarms.build_redshift_holds_deleted_query")
         mocker.patch("alarms.models.holds_alarms.build_redshift_holds_modified_query")
         mocker.patch("alarms.models.holds_alarms.build_redshift_holds_null_query")
-        mocker.patch("alarms.models.holds_alarms.build_redshift_holds_query")
+        mocker.patch("alarms.models.holds_alarms.build_redshift_holds_count_query")
         test_instance.redshift_client.execute_query.side_effect = [
             ([10],),
             ([10],),


### PR DESCRIPTION
These alarms check whether:
1) there are greater than 1000 sessions from the previous day (unfortunately it's not possible to check the exact number without re-running all the processing from the poller)
2) there is only one row per (session id, patron id, domain) combination from the previous day

Also updated the hold alarm that checks whether a previously deleted hold appears again to use timestamps rather than dates, which should prevent it from erroneously firing when a hold is created and deleted in the same day.