### PR TITLE
Add mismatched holds alarm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2025-09-15
+### Added
+- Add mismatched holds alarm
+
 ## 2025-08-25
 ### Added
 - Add EZproxy alarms

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Currently, the code will log an error (triggering an alarm to fire) under the fo
 * When there are no circ trans records in Sierra for the previous day
 * When there are no holds updated in Redshift for the previous day
 * When an invalid hold appears in Redshift for the previous day
+* When a hold appears in the holds queue for the previous day without existing in the Redshift hold info table
 * When the number of PC reserve records in Envisionware and Redshift differs for the previous day
 * When there are no PC reserve records in Sierra for the previous day
 * When the number of OverDrive checkout records online (via OverDrive Marketplace) and in Redshift differs for the previous day

--- a/alarms/models/holds_alarms.py
+++ b/alarms/models/holds_alarms.py
@@ -3,6 +3,7 @@ from datetime import timedelta
 from helpers.query_helper import (
     build_redshift_holds_count_query,
     build_redshift_holds_deleted_query,
+    build_redshift_holds_mismatch_query,
     build_redshift_holds_modified_query,
     build_redshift_holds_null_query,
 )
@@ -19,30 +20,39 @@ class HoldsAlarms(Alarm):
         # The update_timestamp is stored in UTC and the poller is run late at
         # night, so the date for the most recent day of data is today
         date_to_test = (self.yesterday_date + timedelta(days=1)).isoformat()
+
+        redshift_info_table = "hold_info" + self.redshift_suffix
+        redshift_queue_table = "queued_holds" + self.redshift_suffix
         self.redshift_client.connect()
         if self.run_added_tests:
-            for table_name in ["hold_info", "queued_holds"]:
-                redshift_table = table_name + self.redshift_suffix
+            for table in [redshift_info_table, redshift_queue_table]:
                 redshift_count_query = build_redshift_holds_count_query(
-                    redshift_table, date_to_test
+                    table, date_to_test
                 )
                 redshift_count = int(
                     self.redshift_client.execute_query(redshift_count_query)[0][0]
                 )
-                self.check_holds_not_updated_alarm(redshift_count, redshift_table)
+                self.check_holds_not_updated_alarm(redshift_count, table)
 
-        redshift_table = "hold_info" + self.redshift_suffix
+        mismatched_holds = self.redshift_client.execute_query(
+            build_redshift_holds_mismatch_query(
+                redshift_queue_table, redshift_info_table, date_to_test
+            )
+        )
         deleted_holds = self.redshift_client.execute_query(
-            build_redshift_holds_deleted_query(redshift_table, date_to_test)
+            build_redshift_holds_deleted_query(redshift_info_table, date_to_test)
         )
         modified_holds = self.redshift_client.execute_query(
-            build_redshift_holds_modified_query(redshift_table)
+            build_redshift_holds_modified_query(redshift_info_table)
         )
         null_holds = self.redshift_client.execute_query(
-            build_redshift_holds_null_query(redshift_table, date_to_test)
+            build_redshift_holds_null_query(redshift_info_table, date_to_test)
         )
         self.redshift_client.close_connection()
 
+        self.check_mismatched_holds_alarm(
+            redshift_queue_table, redshift_info_table, mismatched_holds
+        )
         self.check_holds_not_deleted_alarm(deleted_holds)
         self.check_immutable_hold_field_updated_alarm(modified_holds)
         self.check_null_hold_id_alarm(null_holds)
@@ -52,6 +62,19 @@ class HoldsAlarms(Alarm):
             self.logger.error(
                 ('"{table}" table not updated for all of {date} ' "(ET)").format(
                     table=redshift_table, date=self.yesterday
+                )
+            )
+
+    def check_mismatched_holds_alarm(self, queue_table, info_table, mismatched_holds):
+        if len(mismatched_holds) > 0:
+            self.logger.error(
+                (
+                    "The following hold_ids appear in {queue_table} but not in "
+                    "{info_table}: {mismatches}"
+                ).format(
+                    queue_table=queue_table,
+                    info_table=info_table,
+                    mismatches=mismatched_holds,
                 )
             )
 
@@ -67,6 +90,13 @@ class HoldsAlarms(Alarm):
             self.logger.error(
                 "The following hold_ids have an immutable field changing: "
                 "{}".format(modified_holds)
+            )
+
+    def check_null_hold_id_alarm(self, null_holds):
+        if len(null_holds) > 0:
+            self.logger.error(
+                "The following hold_ids have an improper null value: "
+                "{}".format(null_holds)
             )
 
     def check_null_hold_id_alarm(self, null_holds):

--- a/helpers/query_helper.py
+++ b/helpers/query_helper.py
@@ -61,6 +61,11 @@ _REDSHIFT_HOLDS_COUNT_QUERY = (
     "SELECT COUNT(id) FROM {table} WHERE TRUNC(update_timestamp) = '{date}';"
 )
 
+_REDSHIFT_HOLDS_MISMATCH_QUERY = """
+    SELECT hold_id FROM {queue_table}
+    WHERE TRUNC(update_timestamp) = '{date}'
+        AND hold_id NOT IN (SELECT hold_id FROM {info_table});"""
+
 _REDSHIFT_HOLDS_DELETED_QUERY = """
     WITH active_holds AS (
         SELECT hold_id, MAX(update_timestamp) as last_active_timestamp
@@ -250,6 +255,12 @@ def build_redshift_ezproxy_duplicate_query(table, date):
 
 def build_redshift_holds_count_query(table, date):
     return _REDSHIFT_HOLDS_COUNT_QUERY.format(table=table, date=date)
+
+
+def build_redshift_holds_mismatch_query(queue_table, info_table, date):
+    return _REDSHIFT_HOLDS_MISMATCH_QUERY.format(
+        queue_table=queue_table, info_table=info_table, date=date
+    )
 
 
 def build_redshift_holds_deleted_query(table, date):


### PR DESCRIPTION
Every hold_id in the BIC should appear in the hold_info table