### PR TITLE
Initial OverDrive title pipeline tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2026-03-13
+### Added
+- Add OverDrive title alarms
+- Update date tested for all OverDrive alarms
+
 ## 2026-02-03
 ### Added
 - Update OverDrive web scraper url data & Chrome driver options

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ Currently, the code will log an error (triggering an alarm to fire) under the fo
 * When an unknown location id appears in location hours
 * When the number of PC reserve records in Envisionware and Redshift differs for the previous day
 * When there are no PC reserve records in Sierra for the previous day
-* When the number of OverDrive checkout records online (via OverDrive Marketplace) and in Redshift differs for the previous day
-* When there are no OverDrive checkout records online (via OverDrive Marketplace) for the previous day
+* When the number of OverDrive checkout records online (via OverDrive Marketplace) and in Redshift from 5 days prior differs 
+* When there are no OverDrive checkout records online (via OverDrive Marketplace) from 5 days ago
 * When the number of newly created/deleted patron records in Sierra and Redshift differs for any day in the previous week
 * When there are no newly created patron records in Sierra for the previous any day in the previous week
 * When a single Sierra branch code maps to multiple Drupal branch codes

--- a/alarm_controller.py
+++ b/alarm_controller.py
@@ -45,8 +45,9 @@ class AlarmController:
             kms_client.decrypt(os.environ["REDSHIFT_DB_PASSWORD"]),
         )
         self.sierra_client = PostgreSQLClient(
-            kms_client.decrypt(os.environ["SIERRA_DB_HOST"]),
-            os.environ["SIERRA_DB_PORT"],
+            # kms_client.decrypt(os.environ["SIERRA_DB_HOST"]),
+            # os.environ["SIERRA_DB_PORT"],
+            "10.199.1.24", "1032",
             os.environ["SIERRA_DB_NAME"],
             kms_client.decrypt(os.environ["SIERRA_DB_USER"]),
             kms_client.decrypt(os.environ["SIERRA_DB_PASSWORD"]),

--- a/alarm_controller.py
+++ b/alarm_controller.py
@@ -45,9 +45,8 @@ class AlarmController:
             kms_client.decrypt(os.environ["REDSHIFT_DB_PASSWORD"]),
         )
         self.sierra_client = PostgreSQLClient(
-            # kms_client.decrypt(os.environ["SIERRA_DB_HOST"]),
-            # os.environ["SIERRA_DB_PORT"],
-            "10.199.1.24", "1032",
+            kms_client.decrypt(os.environ["SIERRA_DB_HOST"]),
+            os.environ["SIERRA_DB_PORT"],
             os.environ["SIERRA_DB_NAME"],
             kms_client.decrypt(os.environ["SIERRA_DB_USER"]),
             kms_client.decrypt(os.environ["SIERRA_DB_PASSWORD"]),

--- a/alarms/models/overdrive_checkouts_alarms.py
+++ b/alarms/models/overdrive_checkouts_alarms.py
@@ -1,4 +1,5 @@
 from alarms.alarm import Alarm
+from datetime import timedelta
 from helpers.alarm_helper import (
     check_redshift_mismatch_alarm,
     check_no_records_found_alarm,
@@ -19,35 +20,41 @@ class OverDriveCheckoutsAlarms(Alarm):
             overdrive_credentials[0], overdrive_credentials[1]
         )
         self.logger = create_log("overdrive_checkouts_alarms")
+        self.date_to_test = self.yesterday_date - timedelta(days=4)
 
     def run_checks(self):
         self.logger.info("OverDrive Checkouts")
+        redshift_tables = ["patron_overdrive_checkouts", "title_overdrive_checkouts"]
+        
         try:
-            overdrive_count = self.overdrive_client.get_count(self.yesterday)
+            overdrive_count = self.overdrive_client.get_count(self.date_to_test)
         except Exception as e:
             self.logger.error(f"Failed to scrape OverDrive Marketplace: {e}")
             return
-
-        redshift_table = "patron_overdrive_checkouts" + self.redshift_suffix
-        redshift_query = build_redshift_ebook_query(redshift_table, self.yesterday)
-        redshift_count = self.get_record_count(self.redshift_client, redshift_query)
+        
+        self.logger.info(f"Checking OD record count from ({self.date_to_test})...")
+        for redshift_table in redshift_tables:
+            table = redshift_table + self.redshift_suffix
+            redshift_query = build_redshift_ebook_query(table, self.date_to_test)
+            redshift_count = self.get_record_count(self.redshift_client, redshift_query)
+            # If there are records in the table, perform further checks
+            adjusted_redshift_count = self._adjust_redshift_count(
+                table, redshift_count
+            )
+            check_redshift_mismatch_alarm(
+                logger=self.logger,
+                database_type="OverDrive Marketplace",
+                redshift_table=table,
+                database_count=overdrive_count,
+                redshift_count=adjusted_redshift_count,
+            )
+        
         check_no_records_found_alarm(
             logger=self.logger,
             database_count=overdrive_count,
             conditional=True,
             database_type="OverDrive Marketplace",
-            date=self.yesterday,
-        )
-        # If there are records in the table, perform further checks
-        adjusted_redshift_count = self._adjust_redshift_count(
-            redshift_table, redshift_count
-        )
-        check_redshift_mismatch_alarm(
-            logger=self.logger,
-            database_type="OverDrive Marketplace",
-            redshift_table=redshift_table,
-            database_count=overdrive_count,
-            redshift_count=adjusted_redshift_count,
+            date=self.date_to_test,
         )
 
     def _adjust_redshift_count(self, redshift_table, initial_redshift_count):
@@ -60,7 +67,7 @@ class OverDriveCheckoutsAlarms(Alarm):
         self.redshift_client.connect()
 
         duplicate_checksums = self.redshift_client.execute_query(
-            build_redshift_overdrive_duplicate_query(redshift_table, self.yesterday)
+            build_redshift_overdrive_duplicate_query(redshift_table, self.date_to_test)
         )
 
         if not duplicate_checksums:
@@ -72,7 +79,7 @@ class OverDriveCheckoutsAlarms(Alarm):
         for checksum in duplicate_checksums:
             platform_types = self.redshift_client.execute_query(
                 build_redshift_overdrive_duplicate_platform_query(
-                    redshift_table, self.yesterday, checksum
+                    redshift_table, self.date_to_test, checksum
                 )
             )
             adjusted_redshift_count -= len(platform_types) - 1

--- a/alarms/models/overdrive_checkouts_alarms.py
+++ b/alarms/models/overdrive_checkouts_alarms.py
@@ -25,22 +25,20 @@ class OverDriveCheckoutsAlarms(Alarm):
     def run_checks(self):
         self.logger.info("OverDrive Checkouts")
         redshift_tables = ["patron_overdrive_checkouts", "title_overdrive_checkouts"]
-        
+
         try:
             overdrive_count = self.overdrive_client.get_count(self.date_to_test)
         except Exception as e:
             self.logger.error(f"Failed to scrape OverDrive Marketplace: {e}")
             return
-        
+
         self.logger.info(f"Checking OD record count from ({self.date_to_test})...")
         for redshift_table in redshift_tables:
             table = redshift_table + self.redshift_suffix
             redshift_query = build_redshift_ebook_query(table, self.date_to_test)
             redshift_count = self.get_record_count(self.redshift_client, redshift_query)
             # If there are records in the table, perform further checks
-            adjusted_redshift_count = self._adjust_redshift_count(
-                table, redshift_count
-            )
+            adjusted_redshift_count = self._adjust_redshift_count(table, redshift_count)
             check_redshift_mismatch_alarm(
                 logger=self.logger,
                 database_type="OverDrive Marketplace",
@@ -48,7 +46,7 @@ class OverDriveCheckoutsAlarms(Alarm):
                 database_count=overdrive_count,
                 redshift_count=adjusted_redshift_count,
             )
-        
+
         check_no_records_found_alarm(
             logger=self.logger,
             database_count=overdrive_count,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-nypl-py-utils[mysql-client,postgresql-client,redshift-client,s3-client,config-helper]==1.7.0
+nypl-py-utils[mysql-client,postgresql-client,redshift-client,s3-client,config-helper]==1.8.0
 selenium

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-nypl-py-utils[mysql-client,postgresql-client,redshift-client,s3-client,config-helper]==1.8.0
+nypl-py-utils[mysql-client,postgresql-client,redshift-client,s3-client,config-helper,log-helper]==1.8.0
 selenium

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-nypl-py-utils[mysql-client,postgresql-client,redshift-client,s3-client,config-helper,log-helper]==1.8.0
+nypl-py-utils[mysql-client,postgresql-client,redshift-client,s3-client,config-helper,log-helper]==1.9.1
 selenium

--- a/tests/alarms/models/test_overdrive_checkouts_alarms.py
+++ b/tests/alarms/models/test_overdrive_checkouts_alarms.py
@@ -2,7 +2,6 @@ import logging
 import pytest
 
 from alarms.models.overdrive_checkouts_alarms import OverDriveCheckoutsAlarms
-from freezegun.api import FakeDate
 from helpers.overdrive_web_scraper import OverDriveWebScraperError
 
 

--- a/tests/alarms/models/test_overdrive_checkouts_alarms.py
+++ b/tests/alarms/models/test_overdrive_checkouts_alarms.py
@@ -2,6 +2,7 @@ import logging
 import pytest
 
 from alarms.models.overdrive_checkouts_alarms import OverDriveCheckoutsAlarms
+from freezegun.api import FakeDate
 from helpers.overdrive_web_scraper import OverDriveWebScraperError
 
 
@@ -33,28 +34,28 @@ class TestOverDriveCheckoutsAlarms:
             "alarms.models.overdrive_checkouts_alarms.build_redshift_overdrive_duplicate_query",
             return_value="redshift od duplicate query",
         )
-        test_instance.redshift_client.execute_query.side_effect = [([10],), ()]
+        test_instance.redshift_client.execute_query.side_effect = [([10],), ()] * 2
         test_instance.overdrive_client.get_count.return_value = 10
+        mock_query_calls = [
+            mocker.call("patron_overdrive_checkouts_test_redshift_db", test_instance.date_to_test),
+            mocker.call("title_overdrive_checkouts_test_redshift_db", test_instance.date_to_test),
+        ]
 
         with caplog.at_level(logging.ERROR):
             test_instance.run_checks()
 
         assert caplog.text == ""
-        assert test_instance.redshift_client.connect.call_count == 2
-        test_instance.overdrive_client.get_count.assert_called_once_with("2023-05-31")
-        mock_redshift_query.assert_called_once_with(
-            "patron_overdrive_checkouts_test_redshift_db", "2023-05-31"
-        )
-        mock_duplicate_query.assert_called_once_with(
-            "patron_overdrive_checkouts_test_redshift_db", "2023-05-31"
-        )
+        assert test_instance.redshift_client.connect.call_count == 4
+        test_instance.overdrive_client.get_count.assert_called_once_with(test_instance.date_to_test)
+        mock_redshift_query.assert_has_calls(mock_query_calls)
+        mock_duplicate_query.assert_has_calls(mock_query_calls)
         test_instance.redshift_client.execute_query.assert_has_calls(
             [
                 mocker.call("redshift od query"),
                 mocker.call("redshift od duplicate query"),
             ]
         )
-        test_instance.redshift_client.close_connection.assert_called_once()
+        assert test_instance.redshift_client.close_connection.call_count == 2
 
     def test_run_checks_unequal_counts_alarm(self, test_instance, mocker, caplog):
         mocker.patch(
@@ -63,7 +64,7 @@ class TestOverDriveCheckoutsAlarms:
         mocker.patch(
             "alarms.models.overdrive_checkouts_alarms.build_redshift_overdrive_duplicate_query"
         )
-        test_instance.redshift_client.execute_query.side_effect = [([10],), ()]
+        test_instance.redshift_client.execute_query.side_effect = [([10],), ()] * 2
         test_instance.overdrive_client.get_count.return_value = 20
 
         with caplog.at_level(logging.ERROR):
@@ -72,6 +73,11 @@ class TestOverDriveCheckoutsAlarms:
         assert (
             "Number of OverDrive Marketplace records does not match number of Redshift "
             "patron_overdrive_checkouts_test_redshift_db records: 20 OverDrive Marketplace "
+            "records and 10 Redshift records"
+        ) in caplog.text
+        assert (
+            "Number of OverDrive Marketplace records does not match number of Redshift "
+            "title_overdrive_checkouts_test_redshift_db records: 20 OverDrive Marketplace "
             "records and 10 Redshift records"
         ) in caplog.text
 
@@ -91,7 +97,7 @@ class TestOverDriveCheckoutsAlarms:
             ([11],),
             (["jQhmtNm/QuLk"],),
             (["OverDrive Read"], ["Kindle Book"]),
-        ]
+        ] * 2
         test_instance.overdrive_client.get_count.return_value = 10
 
         with caplog.at_level(logging.ERROR):
@@ -105,14 +111,14 @@ class TestOverDriveCheckoutsAlarms:
         mocker.patch(
             "alarms.models.overdrive_checkouts_alarms.build_redshift_overdrive_duplicate_query"
         )
-        test_instance.redshift_client.execute_query.side_effect = [([0],), ()]
+        test_instance.redshift_client.execute_query.side_effect = [([0],), ()] * 2
         test_instance.overdrive_client.get_count.return_value = 0
 
         with caplog.at_level(logging.ERROR):
             test_instance.run_checks()
 
         assert (
-            "No OverDrive Marketplace records found for all of 2023-05-31"
+            "No OverDrive Marketplace records found for all of 2023-05-27"
             in caplog.text
         )
 


### PR DESCRIPTION
Very basic tests modeled after the cloudLibrary tests, so it accounts for a data lag of 5 days! The lag isn't really an issue anymore but just to be safe...

Screenshot of qa test run (I intentionally caused a failure by deleting all qa records with the [incorrect transaction id obfuscation](https://github.com/NYPL/overdrive-checkout-poller/pull/23)):
<img width="1649" height="204" alt="Screenshot 2026-03-12 at 1 02 41 PM" src="https://github.com/user-attachments/assets/73e7a83a-a787-4f1a-9c8f-d7a58cb13732" />