### PR TITLE
Update OverDrive tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2026-04-20
+### Added
+- Update OverDrive web scraper to avoid cookie pop-up
+- Fix OverDrive count adjustment so it only applies to patron checkouts
+
 ## 2026-03-13
 ### Added
 - Add OverDrive title alarms

--- a/alarms/models/overdrive_checkouts_alarms.py
+++ b/alarms/models/overdrive_checkouts_alarms.py
@@ -85,7 +85,7 @@ class OverDriveCheckoutsAlarms(Alarm):
                     redshift_table, self.date_to_test, checksum
                 )
             )
-        adjusted_redshift_count -= len(platform_types) - 1
+            adjusted_redshift_count -= len(platform_types) - 1
 
         self.redshift_client.close_connection()
         return adjusted_redshift_count

--- a/alarms/models/overdrive_checkouts_alarms.py
+++ b/alarms/models/overdrive_checkouts_alarms.py
@@ -8,7 +8,7 @@ from helpers.overdrive_web_scraper import OverDriveWebScraper
 from helpers.query_helper import (
     build_redshift_ebook_query,
     build_redshift_overdrive_duplicate_platform_query,
-    build_redshift_overdrive_duplicate_query,
+    build_redshift_overdrive_duplicate_checksum_query,
 )
 from nypl_py_utils.functions.log_helper import create_log
 
@@ -37,14 +37,16 @@ class OverDriveCheckoutsAlarms(Alarm):
             table = redshift_table + self.redshift_suffix
             redshift_query = build_redshift_ebook_query(table, self.date_to_test)
             redshift_count = self.get_record_count(self.redshift_client, redshift_query)
-            # If there are records in the table, perform further checks
-            adjusted_redshift_count = self._adjust_redshift_count(table, redshift_count)
+
+            if "patron_overdrive_checkouts" in table:
+                redshift_count = self._adjust_redshift_count(table, redshift_count)
+
             check_redshift_mismatch_alarm(
                 logger=self.logger,
                 database_type="OverDrive Marketplace",
                 redshift_table=table,
                 database_count=overdrive_count,
-                redshift_count=adjusted_redshift_count,
+                redshift_count=redshift_count,
             )
 
         check_no_records_found_alarm(
@@ -58,14 +60,16 @@ class OverDriveCheckoutsAlarms(Alarm):
     def _adjust_redshift_count(self, redshift_table, initial_redshift_count):
         """
         In OverDrive, when users download titles through different platforms, these
-        transactions are all counted as one row. This is not the case in Redshift --
-        these are separate rows that are otherwise identical aside from the
-        `platform` column. This method accounts for this discrepancy.
+        transactions are all counted as one row. This is not the case for the
+        Redshift OverDrive patron table -- these are separate rows that are otherwise
+        identical aside from the `platform` column. This method accounts for this discrepancy.
         """
         self.redshift_client.connect()
 
         duplicate_checksums = self.redshift_client.execute_query(
-            build_redshift_overdrive_duplicate_query(redshift_table, self.date_to_test)
+            build_redshift_overdrive_duplicate_checksum_query(
+                redshift_table, self.date_to_test
+            )
         )
 
         if not duplicate_checksums:
@@ -74,13 +78,14 @@ class OverDriveCheckoutsAlarms(Alarm):
 
         adjusted_redshift_count = initial_redshift_count
         duplicate_checksums = [checksum for checksum in duplicate_checksums[0]]
+
         for checksum in duplicate_checksums:
             platform_types = self.redshift_client.execute_query(
                 build_redshift_overdrive_duplicate_platform_query(
                     redshift_table, self.date_to_test, checksum
                 )
             )
-            adjusted_redshift_count -= len(platform_types) - 1
+        adjusted_redshift_count -= len(platform_types) - 1
 
         self.redshift_client.close_connection()
         return adjusted_redshift_count

--- a/helpers/overdrive_web_scraper.py
+++ b/helpers/overdrive_web_scraper.py
@@ -90,10 +90,18 @@ class OverDriveWebScraper:
         self.logger.info("Logging into OverDrive")
         self.driver.get(_LOGIN_URL)
         try:
+            # Click out of cookie selection pop-up if present
+            cookie_settings = self.driver.find_elements(
+                By.XPATH, "//*[@id='dialogModalContainer']/dialog/button"
+            )
+            if cookie_settings:
+                cookie_settings[0].click()
+
+            # Input username and password, then submit form
             self.driver.find_element(By.ID, "UserName").send_keys(self.username)
             self.driver.find_element(By.ID, "Password").send_keys(self.password)
             self.driver.find_element(By.XPATH, "//input[@type='submit']").click()
-        except exceptions.NoSuchElementException as e:
+        except Exception as e:
             self.driver.quit()
             self.logger.error(f"Login page elements not found: {e}")
             raise OverDriveWebScraperError(

--- a/helpers/query_helper.py
+++ b/helpers/query_helper.py
@@ -149,13 +149,13 @@ _REDSHIFT_HOURS_LOCATION_ID_QUERY = """
 
 _REDSHIFT_EBOOK_QUERY = "SELECT COUNT(*) FROM {table} WHERE transaction_et = '{date}';"
 
-_REDSHIFT_OVERDRIVE_PLATFORMS_DUPLICATE_TRANSACTION_QUERY = """
+_REDSHIFT_OVERDRIVE_PLATFORMS_DUPLICATE_QUERY = """
     SELECT DISTINCT platform 
     FROM {table} 
     WHERE transaction_et = '{date}'
     AND transaction_checksum = '{checksum}';"""
 
-_REDSHIFT_OVERDRIVE_DUPLICATE_TRANSACTIONS_QUERY = """
+_REDSHIFT_OVERDRIVE_FIND_DUPLICATE_CHECKSUMS_QUERY = """
     SELECT transaction_checksum 
     FROM {table} 
     WHERE transaction_et = '{date}'
@@ -335,14 +335,14 @@ def build_redshift_ebook_query(table, date):
     return _REDSHIFT_EBOOK_QUERY.format(table=table, date=date)
 
 
-def build_redshift_overdrive_duplicate_query(table, date):
-    return _REDSHIFT_OVERDRIVE_DUPLICATE_TRANSACTIONS_QUERY.format(
+def build_redshift_overdrive_duplicate_checksum_query(table, date):
+    return _REDSHIFT_OVERDRIVE_FIND_DUPLICATE_CHECKSUMS_QUERY.format(
         table=table, date=date
     )
 
 
 def build_redshift_overdrive_duplicate_platform_query(table, date, checksum):
-    return _REDSHIFT_OVERDRIVE_PLATFORMS_DUPLICATE_TRANSACTION_QUERY.format(
+    return _REDSHIFT_OVERDRIVE_PLATFORMS_DUPLICATE_QUERY.format(
         table=table, date=date, checksum=checksum
     )
 

--- a/tests/alarms/models/test_overdrive_checkouts_alarms.py
+++ b/tests/alarms/models/test_overdrive_checkouts_alarms.py
@@ -30,24 +30,31 @@ class TestOverDriveCheckoutsAlarms:
             return_value="redshift od query",
         )
         mock_duplicate_query = mocker.patch(
-            "alarms.models.overdrive_checkouts_alarms.build_redshift_overdrive_duplicate_query",
+            "alarms.models.overdrive_checkouts_alarms.build_redshift_overdrive_duplicate_checksum_query",
             return_value="redshift od duplicate query",
         )
         test_instance.redshift_client.execute_query.side_effect = [([10],), ()] * 2
         test_instance.overdrive_client.get_count.return_value = 10
-        mock_query_calls = [
-            mocker.call("patron_overdrive_checkouts_test_redshift_db", test_instance.date_to_test),
-            mocker.call("title_overdrive_checkouts_test_redshift_db", test_instance.date_to_test),
-        ]
 
         with caplog.at_level(logging.ERROR):
             test_instance.run_checks()
 
         assert caplog.text == ""
-        assert test_instance.redshift_client.connect.call_count == 4
+        assert test_instance.redshift_client.connect.call_count == 3
         test_instance.overdrive_client.get_count.assert_called_once_with(test_instance.date_to_test)
-        mock_redshift_query.assert_has_calls(mock_query_calls)
-        mock_duplicate_query.assert_has_calls(mock_query_calls)
+        mock_redshift_query.assert_has_calls(
+            [
+                mocker.call(
+                    "patron_overdrive_checkouts_test_redshift_db",
+                    test_instance.date_to_test,
+                ),
+                mocker.call(
+                    "title_overdrive_checkouts_test_redshift_db",
+                    test_instance.date_to_test,
+                ),
+            ]
+        )
+        mock_duplicate_query.assert_called_once_with("patron_overdrive_checkouts_test_redshift_db", test_instance.date_to_test)
         test_instance.redshift_client.execute_query.assert_has_calls(
             [
                 mocker.call("redshift od query"),
@@ -61,7 +68,7 @@ class TestOverDriveCheckoutsAlarms:
             "alarms.models.overdrive_checkouts_alarms.build_redshift_ebook_query"
         )
         mocker.patch(
-            "alarms.models.overdrive_checkouts_alarms.build_redshift_overdrive_duplicate_query"
+            "alarms.models.overdrive_checkouts_alarms.build_redshift_overdrive_duplicate_checksum_query"
         )
         test_instance.redshift_client.execute_query.side_effect = [([10],), ()] * 2
         test_instance.overdrive_client.get_count.return_value = 20
@@ -87,16 +94,15 @@ class TestOverDriveCheckoutsAlarms:
             "alarms.models.overdrive_checkouts_alarms.build_redshift_ebook_query",
         )
         mocker.patch(
-            "alarms.models.overdrive_checkouts_alarms.build_redshift_overdrive_duplicate_query"
+            "alarms.models.overdrive_checkouts_alarms.build_redshift_overdrive_duplicate_checksum_query"
         )
         mocker.patch(
             "alarms.models.overdrive_checkouts_alarms.build_redshift_overdrive_duplicate_platform_query"
         )
         test_instance.redshift_client.execute_query.side_effect = [
-            ([11],),
-            (["jQhmtNm/QuLk"],),
-            (["OverDrive Read"], ["Kindle Book"]),
-        ] * 2
+            ([11],),(["jQhmtNm/QuLk"],),
+            (["OverDrive Read"], ["Kindle Book"]), ([10],)
+        ]
         test_instance.overdrive_client.get_count.return_value = 10
 
         with caplog.at_level(logging.ERROR):
@@ -108,7 +114,7 @@ class TestOverDriveCheckoutsAlarms:
             "alarms.models.overdrive_checkouts_alarms.build_redshift_ebook_query"
         )
         mocker.patch(
-            "alarms.models.overdrive_checkouts_alarms.build_redshift_overdrive_duplicate_query"
+            "alarms.models.overdrive_checkouts_alarms.build_redshift_overdrive_duplicate_checksum_query"
         )
         test_instance.redshift_client.execute_query.side_effect = [([0],), ()] * 2
         test_instance.overdrive_client.get_count.return_value = 0

--- a/tests/helpers/test_overdrive_web_scraper.py
+++ b/tests/helpers/test_overdrive_web_scraper.py
@@ -112,6 +112,9 @@ class TestOverDriveWebScraper:
             [mocker.call(By.ID, "UserName"),
              mocker.call(By.ID, "Password"),
              mocker.call(By.XPATH, "//input[@type='submit']")])
+        test_instance.driver.find_elements.assert_called_once_with(
+            By.XPATH, "//*[@id='dialogModalContainer']/dialog/button"
+        )
         mock_username_el.send_keys.assert_called_once_with("mock_overdrive_username")
         mock_password_el.send_keys.assert_called_once_with("mock_overdrive_password")
         mock_submit_el.click.assert_called_once()


### PR DESCRIPTION
Fixes in response to the [4/19 bic-alarms errors](https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:log-groups/log-group/$252Fecs$252Fbic-alarms-production/log-events/$3Fstart$3D1776312000000$26end$3D1776712381000$26filterPattern$3D$257E$2527*3f*22ERROR*22*20*3f*22Error*22*20*3f*22error*22*20*3f*22WARNING*22*20*3f*22Warning*22*20*3f*22warning*22):
- Update OverDrive web scraper to avoid cookie pop-up ([related PR](https://github.com/NYPL/overdrive-checkout-poller/pull/28))
- Fix OverDrive count adjustment so it only applies to patron checkouts
- Minor renaming of functions for clarity