### PR TITLE
Temporarily ignore known bad hold timestamps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2026-05-06
+### Fixed
+- Update holds alarms to always take in a specific date to test
+- Temporarily ignore holds alarms from 5/2 and 5/3
+
 ## 2026-04-20
 ### Added
 - Update OverDrive web scraper to avoid cookie pop-up

--- a/alarms/models/holds_alarms.py
+++ b/alarms/models/holds_alarms.py
@@ -43,7 +43,7 @@ class HoldsAlarms(Alarm):
             build_redshift_holds_deleted_query(redshift_info_table, date_to_test)
         )
         modified_holds = self.redshift_client.execute_query(
-            build_redshift_holds_modified_query(redshift_info_table)
+            build_redshift_holds_modified_query(redshift_info_table, date_to_test)
         )
         null_holds = self.redshift_client.execute_query(
             build_redshift_holds_null_query(redshift_info_table, date_to_test)

--- a/helpers/query_helper.py
+++ b/helpers/query_helper.py
@@ -79,22 +79,33 @@ _REDSHIFT_HOLDS_DELETED_QUERY = """
         WHERE TRUNC(update_timestamp) = '{date}' AND record_id IS NOT NULL
         GROUP BY hold_id
     ), deleted_holds AS (
-        SELECT hold_id, update_timestamp AS deleted_timestamp
+        SELECT hold_id, MAX(update_timestamp) AS last_deleted_timestamp
         FROM {table}
         WHERE record_id IS NULL AND hold_id IN (SELECT hold_id FROM active_holds)
+        GROUP BY hold_id
     )
     SELECT active_holds.hold_id
     FROM active_holds INNER JOIN deleted_holds
         ON active_holds.hold_id = deleted_holds.hold_id
-    WHERE last_active_timestamp >= deleted_timestamp;"""
+    WHERE last_active_timestamp >= last_deleted_timestamp
+        AND (
+            last_deleted_timestamp < '2026-05-02 21:00:00'
+            OR last_deleted_timestamp > '2026-05-03 10:00:00'
+        );"""
 
 _REDSHIFT_HOLDS_MODIFIED_QUERY = """
     SELECT hold_id FROM {table}
-    WHERE hold_id NOT IN (
-        SELECT hold_id FROM {table}
-        WHERE record_id IS NULL
-            AND record_type IS NULL
-            AND placed_utc IS NULL)
+    WHERE
+        hold_id IN (
+            SELECT hold_id
+            FROM {table}
+            WHERE TRUNC(update_timestamp) = '{date}'
+        )
+        AND hold_id NOT IN (
+            SELECT hold_id FROM {table}
+            WHERE record_id IS NULL
+                AND record_type IS NULL
+                AND placed_utc IS NULL)
     GROUP BY hold_id
     HAVING COUNT(DISTINCT record_id) > 1
         OR COUNT(DISTINCT record_type) > 1
@@ -298,8 +309,8 @@ def build_redshift_holds_deleted_query(table, date):
     return _REDSHIFT_HOLDS_DELETED_QUERY.format(table=table, date=date)
 
 
-def build_redshift_holds_modified_query(table):
-    return _REDSHIFT_HOLDS_MODIFIED_QUERY.format(table=table)
+def build_redshift_holds_modified_query(table, date):
+    return _REDSHIFT_HOLDS_MODIFIED_QUERY.format(table=table, date=date)
 
 
 def build_redshift_holds_null_query(table, date):

--- a/tests/alarms/models/test_holds_alarms.py
+++ b/tests/alarms/models/test_holds_alarms.py
@@ -66,7 +66,9 @@ class TestHoldsAlarms:
         mock_deleted_query.assert_called_once_with(
             "hold_info_test_redshift_db", "2023-06-01"
         )
-        mock_modified_query.assert_called_once_with("hold_info_test_redshift_db")
+        mock_modified_query.assert_called_once_with(
+            "hold_info_test_redshift_db", "2023-06-01"
+        )
         mock_null_query.assert_called_once_with(
             "hold_info_test_redshift_db", "2023-06-01"
         )


### PR DESCRIPTION
Hopefully in the future, holds from this time range will naturally expire and we can remove the hardcoded timestamp check.