### PR TITLE
Do not subtract one from stat group code Redshift counts anymore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2026-05-11
+### Fixed
+- Update stat group alarms to use exact Sierra count now that code 0 exists
+
 ## 2026-05-06
 ### Fixed
 - Update holds alarms to always take in a specific date to test

--- a/alarms/models/sierra_codes/sierra_stat_group_codes_alarms.py
+++ b/alarms/models/sierra_codes/sierra_stat_group_codes_alarms.py
@@ -1,4 +1,3 @@
-from venv import create
 from alarms.alarm import Alarm
 from helpers.query_helper import (
     build_redshift_code_counts_query,
@@ -33,10 +32,8 @@ class SierraStatGroupCodesAlarms(Alarm):
             build_redshift_code_counts_query("stat_group_code", stat_group_table)
         )[0]
 
-        # Subtract one from Redshift counts because stat group code 0 is
-        # manually maintained and not present in Sierra for technical reasons
-        total_redshift_count = int(redshift_counts[0]) - 1
-        distinct_redshift_count = int(redshift_counts[1]) - 1
+        total_redshift_count = int(redshift_counts[0])
+        distinct_redshift_count = int(redshift_counts[1])
         if self.run_added_tests:
             null_stat_group_codes = self.redshift_client.execute_query(
                 build_redshift_stat_group_null_query(stat_group_table, self.yesterday)

--- a/tests/alarms/models/sierra_codes/test_sierra_stat_group_codes_alarms.py
+++ b/tests/alarms/models/sierra_codes/test_sierra_stat_group_codes_alarms.py
@@ -44,7 +44,7 @@ class TestSierraItypeCodesAlarms:
         )
 
         test_instance.sierra_client.execute_query.return_value = [(10,)]
-        test_instance.redshift_client.execute_query.side_effect = [([11, 11],), (), ()]
+        test_instance.redshift_client.execute_query.side_effect = [([10, 10],), (), ()]
 
         with caplog.at_level(logging.ERROR):
             test_instance.run_checks()
@@ -92,7 +92,7 @@ class TestSierraItypeCodesAlarms:
             "alarms.models.sierra_codes.sierra_stat_group_codes_alarms.build_redshift_stat_group_location_query"
         )
         test_instance.sierra_client.execute_query.return_value = [(10,)]
-        test_instance.redshift_client.execute_query.side_effect = [([21, 21],), (), ()]
+        test_instance.redshift_client.execute_query.side_effect = [([20, 20],), (), ()]
 
         with caplog.at_level(logging.ERROR):
             test_instance.run_checks()
@@ -116,7 +116,7 @@ class TestSierraItypeCodesAlarms:
             "alarms.models.sierra_codes.sierra_stat_group_codes_alarms.build_redshift_stat_group_location_query"
         )
         test_instance.sierra_client.execute_query.return_value = [(10,)]
-        test_instance.redshift_client.execute_query.side_effect = [([11, 10],), (), ()]
+        test_instance.redshift_client.execute_query.side_effect = [([10, 9],), (), ()]
 
         with caplog.at_level(logging.ERROR):
             test_instance.run_checks()
@@ -141,7 +141,7 @@ class TestSierraItypeCodesAlarms:
         )
         test_instance.sierra_client.execute_query.return_value = [(10,)]
         test_instance.redshift_client.execute_query.side_effect = [
-            ([11, 11],),
+            ([10, 10],),
             ([1], [2]),
             (),
         ]
@@ -168,7 +168,7 @@ class TestSierraItypeCodesAlarms:
         )
         test_instance.sierra_client.execute_query.return_value = [(10,)]
         test_instance.redshift_client.execute_query.side_effect = [
-            ([11, 11],),
+            ([10, 10],),
             (),
             ([3], [4]),
         ]


### PR DESCRIPTION
This was only necessary when stat group code 0 did not exist in Sierra but was manually maintained in Redshift. Now it exists in Sierra!