### PR TITLE
First pass at overdrive inconsistency alarm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2026-07-07
+### Added
+- Alarms to handle inconsistencies between Overdrive and Redshift
+
 ## 2026-06-16
 ### Added
 - Alarms to handle ptype code checks between sierra and redshift

--- a/alarms/models/cloudlibrary_alarms.py
+++ b/alarms/models/cloudlibrary_alarms.py
@@ -1,7 +1,7 @@
 from alarms.alarm import Alarm
 from datetime import timedelta
 from helpers.alarm_helper import check_no_records_found_alarm
-from helpers.query_helper import build_redshift_ebook_query
+from helpers.query_helper import build_redshift_daily_ebook_query
 from nypl_py_utils.functions.log_helper import create_log
 
 
@@ -18,7 +18,7 @@ class CloudLibraryAlarms(Alarm):
         redshift_table = "cloudlibrary_transactions" + self.redshift_suffix
 
         self.logger.info(f"Checking CL record count from ({date_to_test})...")
-        redshift_query = build_redshift_ebook_query(redshift_table, date_to_test)
+        redshift_query = build_redshift_daily_ebook_query(redshift_table, date_to_test)
         redshift_count = self.get_record_count(self.redshift_client, redshift_query)
         check_no_records_found_alarm(
             logger=self.logger,

--- a/alarms/models/overdrive_checkouts_alarms.py
+++ b/alarms/models/overdrive_checkouts_alarms.py
@@ -21,7 +21,7 @@ class OverDriveCheckoutsAlarms(Alarm):
             overdrive_credentials[0], overdrive_credentials[1]
         )
         self.logger = create_log("overdrive_checkouts_alarms")
-        self.daily_date_to_test = self.yesterday_date - timedelta(days=4)
+        self.daily_test_date = self.yesterday_date - timedelta(days=4)
         # This is to make monthly checks start date 36 days before the current day
         self.monthly_test_start_date = self.yesterday_date - timedelta(days=35)
 
@@ -31,26 +31,24 @@ class OverDriveCheckoutsAlarms(Alarm):
         try:
             self.overdrive_client.overdrive_login()
             overdrive_count = self.overdrive_client.get_count(
-                self.daily_date_to_test, self.daily_date_to_test
+                self.daily_test_date, self.daily_test_date
             )
         except Exception as e:
             self.logger.error(f"Failed to scrape OverDrive Marketplace: {e}")
             self.overdrive_client.quit_driver()
             return
 
-        self.logger.info(
-            f"Checking OD record count from ({self.daily_date_to_test})..."
-        )
+        self.logger.info(f"Checking OD record count from ({self.daily_test_date})...")
         self._run_redshift_checks(overdrive_count, monthly_check=False)
 
         # The 'weekday' method returns Thursday as 3 so this check will run every Friday
         if self.yesterday_date.weekday() == 3:
             try:
                 self.logger.info(
-                    f"Running weekly check for inconsistencies between overdrive and redshift for the dates between {self.monthly_test_start_date} - {self.daily_date_to_test}"
+                    f"Running weekly check for inconsistencies between overdrive and redshift for the dates between {self.monthly_test_start_date} - {self.daily_test_date}"
                 )
                 monthly_overdrive_count = self.overdrive_client.get_count(
-                    self.monthly_test_start_date, self.daily_date_to_test
+                    self.monthly_test_start_date, self.daily_test_date
                 )
                 self._run_redshift_checks(monthly_overdrive_count, monthly_check=True)
             except Exception as e:
@@ -64,7 +62,7 @@ class OverDriveCheckoutsAlarms(Alarm):
             database_count=overdrive_count,
             conditional=True,
             database_type="OverDrive Marketplace",
-            date=self.daily_date_to_test,
+            date=self.daily_test_date,
         )
 
     def _run_redshift_checks(self, overdrive_count, monthly_check=False):
@@ -73,11 +71,11 @@ class OverDriveCheckoutsAlarms(Alarm):
             table = redshift_table + self.redshift_suffix
             if monthly_check:
                 redshift_query = build_redshift_monthly_ebook_query(
-                    table, self.monthly_test_start_date, self.daily_date_to_test
+                    table, self.monthly_test_start_date, self.daily_test_date
                 )
             else:
                 redshift_query = build_redshift_daily_ebook_query(
-                    table, self.daily_date_to_test
+                    table, self.daily_test_date
                 )
             redshift_count = self.get_record_count(self.redshift_client, redshift_query)
 
@@ -109,11 +107,11 @@ class OverDriveCheckoutsAlarms(Alarm):
             overdrive_duplicate_query = build_redshift_monthly_overdrive_platform_query(
                 redshift_table,
                 self.monthly_test_start_date,
-                self.daily_date_to_test,
+                self.daily_test_date,
             )
         else:
             overdrive_duplicate_query = build_redshift_daily_overdrive_platform_query(
-                redshift_table, self.daily_date_to_test
+                redshift_table, self.daily_test_date
             )
 
         duplicate_result = self.redshift_client.execute_query(overdrive_duplicate_query)

--- a/alarms/models/overdrive_checkouts_alarms.py
+++ b/alarms/models/overdrive_checkouts_alarms.py
@@ -1,14 +1,15 @@
 from alarms.alarm import Alarm
-from datetime import timedelta
+from datetime import timedelta, timezone
 from helpers.alarm_helper import (
     check_redshift_mismatch_alarm,
     check_no_records_found_alarm,
 )
 from helpers.overdrive_web_scraper import OverDriveWebScraper
 from helpers.query_helper import (
-    build_redshift_ebook_query,
-    build_redshift_overdrive_duplicate_platform_query,
-    build_redshift_overdrive_duplicate_checksum_query,
+    build_redshift_daily_ebook_query,
+    build_redshift_monthly_ebook_query,
+    build_redshift_daily_overdrive_platform_query,
+    build_redshift_monthly_overdrive_platform_query,
 )
 from nypl_py_utils.functions.log_helper import create_log
 
@@ -20,26 +21,69 @@ class OverDriveCheckoutsAlarms(Alarm):
             overdrive_credentials[0], overdrive_credentials[1]
         )
         self.logger = create_log("overdrive_checkouts_alarms")
-        self.date_to_test = self.yesterday_date - timedelta(days=4)
+        self.daily_date_to_test = self.yesterday_date - timedelta(days=4)
+        self.monthly_test_start_date = self.yesterday_date - timedelta(days=6)
+        self.monthly_test_end_date = self.yesterday_date - timedelta(days=36)
 
     def run_checks(self):
         self.logger.info("OverDrive Checkouts")
-        redshift_tables = ["patron_overdrive_checkouts", "title_overdrive_checkouts"]
 
         try:
-            overdrive_count = self.overdrive_client.get_count(self.date_to_test)
+            self.overdrive_client.overdrive_login()
+            overdrive_count = self.overdrive_client.get_count(
+                self.daily_date_to_test, self.daily_date_to_test
+            )
         except Exception as e:
             self.logger.error(f"Failed to scrape OverDrive Marketplace: {e}")
+            self.overdrive_client.quit_driver()
             return
 
-        self.logger.info(f"Checking OD record count from ({self.date_to_test})...")
+        self.logger.info(
+            f"Checking OD record count from ({self.daily_date_to_test})..."
+        )
+        self._run_redshift_checks(overdrive_count, monthly_check=False)
+
+        # Run the monthly checks every Thursday
+        if self.yesterday_date.weekday() == 3:
+            try:
+                self.logger.info("Weekly check for overdrive discrepancies")
+                monthly_overdrive_count = self.overdrive_client.get_count(
+                    self.monthly_test_start_date, self.monthly_test_end_date
+                )
+            except Exception as e:
+                self.logger.error(f"Failed to scrape OverDrive Marketplace: {e}")
+                self.overdrive_client.quit_driver()
+                return
+
+            self._run_redshift_checks(monthly_overdrive_count, monthly_check=True)
+
+        self.overdrive_client.quit_driver()
+        check_no_records_found_alarm(
+            logger=self.logger,
+            database_count=overdrive_count,
+            conditional=True,
+            database_type="OverDrive Marketplace",
+            date=self.daily_date_to_test,
+        )
+
+    def _run_redshift_checks(self, overdrive_count, monthly_check=False):
+        redshift_tables = ["patron_overdrive_checkouts", "title_overdrive_checkouts"]
         for redshift_table in redshift_tables:
             table = redshift_table + self.redshift_suffix
-            redshift_query = build_redshift_ebook_query(table, self.date_to_test)
+            if monthly_check:
+                redshift_query = build_redshift_monthly_ebook_query(
+                    table, self.monthly_test_start_date, self.monthly_test_end_date
+                )
+            else:
+                redshift_query = build_redshift_daily_ebook_query(
+                    table, self.daily_date_to_test
+                )
             redshift_count = self.get_record_count(self.redshift_client, redshift_query)
 
             if "patron_overdrive_checkouts" in table:
-                redshift_count = self._adjust_redshift_count(table, redshift_count)
+                redshift_count = self._adjust_redshift_count(
+                    table, redshift_count, monthly_check
+                )
 
             check_redshift_mismatch_alarm(
                 logger=self.logger,
@@ -49,15 +93,9 @@ class OverDriveCheckoutsAlarms(Alarm):
                 redshift_count=redshift_count,
             )
 
-        check_no_records_found_alarm(
-            logger=self.logger,
-            database_count=overdrive_count,
-            conditional=True,
-            database_type="OverDrive Marketplace",
-            date=self.date_to_test,
-        )
-
-    def _adjust_redshift_count(self, redshift_table, initial_redshift_count):
+    def _adjust_redshift_count(
+        self, redshift_table, initial_redshift_count, monthly_check=False
+    ):
         """
         In OverDrive, when users download titles through different platforms, these
         transactions are all counted as one row. This is not the case for the
@@ -66,26 +104,27 @@ class OverDriveCheckoutsAlarms(Alarm):
         """
         self.redshift_client.connect()
 
-        duplicate_checksums = self.redshift_client.execute_query(
-            build_redshift_overdrive_duplicate_checksum_query(
-                redshift_table, self.date_to_test
-            )
-        )
-
-        if not duplicate_checksums:
-            # if the resulting tuple is empty, return original count
-            return initial_redshift_count
-
-        adjusted_redshift_count = initial_redshift_count
-        duplicate_checksums = [checksum for checksum in duplicate_checksums[0]]
-
-        for checksum in duplicate_checksums:
-            platform_types = self.redshift_client.execute_query(
-                build_redshift_overdrive_duplicate_platform_query(
-                    redshift_table, self.date_to_test, checksum
+        if monthly_check:
+            discrepancy_query = (
+                build_redshift_monthly_overdrive_platform_query(
+                    redshift_table,
+                    self.monthly_test_start_date,
+                    self.monthly_test_end_date,
                 )
             )
-            adjusted_redshift_count -= len(platform_types) - 1
+        else:
+            discrepancy_query = (
+                build_redshift_daily_overdrive_platform_query(
+                    redshift_table, self.daily_date_to_test
+                )
+            )
+
+        discrepancy_result = self.redshift_client.execute_query(discrepancy_query)
+        discrepancy_count = (
+            int(discrepancy_result[0][0])
+            if discrepancy_result and discrepancy_result[0][0]
+            else 0
+        )
 
         self.redshift_client.close_connection()
-        return adjusted_redshift_count
+        return initial_redshift_count - discrepancy_count

--- a/alarms/models/overdrive_checkouts_alarms.py
+++ b/alarms/models/overdrive_checkouts_alarms.py
@@ -25,7 +25,7 @@ class OverDriveCheckoutsAlarms(Alarm):
         self.monthly_test_start_date = self.yesterday_date - timedelta(days=36)
 
     def run_checks(self):
-        self.logger.info("Over\Drive Checkouts")
+        self.logger.info("OverDrive Checkouts")
 
         try:
             self.overdrive_client.overdrive_login()
@@ -43,7 +43,7 @@ class OverDriveCheckoutsAlarms(Alarm):
         self._run_redshift_checks(overdrive_count, monthly_check=False)
 
         # The 'weekday' method returns Thursday as 3 so this check will run every Friday
-        if self.yesterday_date.weekday() == 1:
+        if self.yesterday_date.weekday() == 3:
             try:
                 self.logger.info(
                     f"Running weekly check for inconsistencies between overdrive and redshift for the dates between {self.monthly_test_start_date} - {self.daily_date_to_test}"

--- a/alarms/models/overdrive_checkouts_alarms.py
+++ b/alarms/models/overdrive_checkouts_alarms.py
@@ -105,18 +105,14 @@ class OverDriveCheckoutsAlarms(Alarm):
         self.redshift_client.connect()
 
         if monthly_check:
-            discrepancy_query = (
-                build_redshift_monthly_overdrive_platform_query(
-                    redshift_table,
-                    self.monthly_test_start_date,
-                    self.monthly_test_end_date,
-                )
+            discrepancy_query = build_redshift_monthly_overdrive_platform_query(
+                redshift_table,
+                self.monthly_test_start_date,
+                self.monthly_test_end_date,
             )
         else:
-            discrepancy_query = (
-                build_redshift_daily_overdrive_platform_query(
-                    redshift_table, self.daily_date_to_test
-                )
+            discrepancy_query = build_redshift_daily_overdrive_platform_query(
+                redshift_table, self.daily_date_to_test
             )
 
         discrepancy_result = self.redshift_client.execute_query(discrepancy_query)

--- a/alarms/models/overdrive_checkouts_alarms.py
+++ b/alarms/models/overdrive_checkouts_alarms.py
@@ -7,8 +7,8 @@ from helpers.alarm_helper import (
 from helpers.overdrive_web_scraper import OverDriveWebScraper
 from helpers.query_helper import (
     build_redshift_daily_ebook_query,
-    build_redshift_monthly_ebook_query,
     build_redshift_daily_overdrive_platform_query,
+    build_redshift_monthly_ebook_query,
     build_redshift_monthly_overdrive_platform_query,
 )
 from nypl_py_utils.functions.log_helper import create_log
@@ -22,11 +22,10 @@ class OverDriveCheckoutsAlarms(Alarm):
         )
         self.logger = create_log("overdrive_checkouts_alarms")
         self.daily_date_to_test = self.yesterday_date - timedelta(days=4)
-        self.monthly_test_start_date = self.yesterday_date - timedelta(days=6)
-        self.monthly_test_end_date = self.yesterday_date - timedelta(days=36)
+        self.monthly_test_start_date = self.yesterday_date - timedelta(days=36)
 
     def run_checks(self):
-        self.logger.info("OverDrive Checkouts")
+        self.logger.info("Over\Drive Checkouts")
 
         try:
             self.overdrive_client.overdrive_login()
@@ -44,18 +43,19 @@ class OverDriveCheckoutsAlarms(Alarm):
         self._run_redshift_checks(overdrive_count, monthly_check=False)
 
         # The 'weekday' method returns Thursday as 3 so this check will run every Friday
-        if self.yesterday_date.weekday() == 3:
+        if self.yesterday_date.weekday() == 1:
             try:
-                self.logger.info("Weekly check for month long overdrive discrepancies")
-                monthly_overdrive_count = self.overdrive_client.get_count(
-                    self.monthly_test_start_date, self.monthly_test_end_date
+                self.logger.info(
+                    f"Running weekly check for inconsistencies between overdrive and redshift for the dates between {self.monthly_test_start_date} - {self.daily_date_to_test}"
                 )
+                monthly_overdrive_count = self.overdrive_client.get_count(
+                    self.monthly_test_start_date, self.daily_date_to_test
+                )
+                self._run_redshift_checks(monthly_overdrive_count, monthly_check=True)
             except Exception as e:
                 self.logger.error(f"Failed to scrape OverDrive Marketplace: {e}")
                 self.overdrive_client.quit_driver()
                 return
-
-            self._run_redshift_checks(monthly_overdrive_count, monthly_check=True)
 
         self.overdrive_client.quit_driver()
         check_no_records_found_alarm(
@@ -72,7 +72,7 @@ class OverDriveCheckoutsAlarms(Alarm):
             table = redshift_table + self.redshift_suffix
             if monthly_check:
                 redshift_query = build_redshift_monthly_ebook_query(
-                    table, self.monthly_test_start_date, self.monthly_test_end_date
+                    table, self.monthly_test_start_date, self.daily_date_to_test
                 )
             else:
                 redshift_query = build_redshift_daily_ebook_query(
@@ -108,7 +108,7 @@ class OverDriveCheckoutsAlarms(Alarm):
             overdrive_duplicate_query = build_redshift_monthly_overdrive_platform_query(
                 redshift_table,
                 self.monthly_test_start_date,
-                self.monthly_test_end_date,
+                self.daily_date_to_test,
             )
         else:
             overdrive_duplicate_query = build_redshift_daily_overdrive_platform_query(

--- a/alarms/models/overdrive_checkouts_alarms.py
+++ b/alarms/models/overdrive_checkouts_alarms.py
@@ -22,7 +22,8 @@ class OverDriveCheckoutsAlarms(Alarm):
         )
         self.logger = create_log("overdrive_checkouts_alarms")
         self.daily_date_to_test = self.yesterday_date - timedelta(days=4)
-        self.monthly_test_start_date = self.yesterday_date - timedelta(days=36)
+        # This is to make monthly checks start date 36 days before the current day
+        self.monthly_test_start_date = self.yesterday_date - timedelta(days=35)
 
     def run_checks(self):
         self.logger.info("OverDrive Checkouts")

--- a/alarms/models/overdrive_checkouts_alarms.py
+++ b/alarms/models/overdrive_checkouts_alarms.py
@@ -43,10 +43,10 @@ class OverDriveCheckoutsAlarms(Alarm):
         )
         self._run_redshift_checks(overdrive_count, monthly_check=False)
 
-        # Run the monthly checks every Thursday
+        # The 'weekday' method returns Thursday as 3 so this check will run every Friday
         if self.yesterday_date.weekday() == 3:
             try:
-                self.logger.info("Weekly check for overdrive discrepancies")
+                self.logger.info("Weekly check for month long overdrive discrepancies")
                 monthly_overdrive_count = self.overdrive_client.get_count(
                     self.monthly_test_start_date, self.monthly_test_end_date
                 )
@@ -105,22 +105,22 @@ class OverDriveCheckoutsAlarms(Alarm):
         self.redshift_client.connect()
 
         if monthly_check:
-            discrepancy_query = build_redshift_monthly_overdrive_platform_query(
+            overdrive_duplicate_query = build_redshift_monthly_overdrive_platform_query(
                 redshift_table,
                 self.monthly_test_start_date,
                 self.monthly_test_end_date,
             )
         else:
-            discrepancy_query = build_redshift_daily_overdrive_platform_query(
+            overdrive_duplicate_query = build_redshift_daily_overdrive_platform_query(
                 redshift_table, self.daily_date_to_test
             )
 
-        discrepancy_result = self.redshift_client.execute_query(discrepancy_query)
-        discrepancy_count = (
-            int(discrepancy_result[0][0])
-            if discrepancy_result and discrepancy_result[0][0]
+        duplicate_result = self.redshift_client.execute_query(overdrive_duplicate_query)
+        duplicate_count = (
+            int(duplicate_result[0][0])
+            if duplicate_result and duplicate_result[0][0]
             else 0
         )
 
         self.redshift_client.close_connection()
-        return initial_redshift_count - discrepancy_count
+        return initial_redshift_count - duplicate_count

--- a/helpers/overdrive_web_scraper.py
+++ b/helpers/overdrive_web_scraper.py
@@ -1,4 +1,5 @@
 import os
+import time
 
 from nypl_py_utils.functions.log_helper import create_log
 from selenium import webdriver
@@ -44,16 +45,31 @@ class OverDriveWebScraper:
         for option in options:
             self.chrome_options.add_argument(option)
 
-    def get_count(self, date):
+    def get_count(self, start_date, end_date):
+        self.logger.info(
+            f"Getting OverDrive Marketplace record count for the range {start_date} - {end_date}"
+        )
+        url = _BASE_URL.format("Checkouts") + quote(
+            _URL_DATA.format(
+                start=start_date, end=end_date, code="null", name="null", limit="50"
+            )
+        )
+        self._access_page(url)
+        # The text should be in the format "Checkouts (1,234)"
+        count = self._get_row_count()
+
+        return int(count[count.find("(") + 1 : count.find(")")])
+
+    def overdrive_login(self):
         self.logger.info("Opening Chrome web driver")
         self.driver = webdriver.Chrome(options=self.chrome_options)
         self.driver.maximize_window()
         self._log_in()
 
-        self.logger.info(f"Getting OverDrive Marketplace record count for {date}")
-        url = _BASE_URL.format("Checkouts") + quote(
-            _URL_DATA.format(start=date, end=date, code="null", name="null", limit="50")
-        )
+    def quit_driver(self):
+        self.driver.quit()
+
+    def _access_page(self, url):
         try:
             self.driver.get(url)
             WebDriverWait(self.driver, timeout=30).until(
@@ -70,6 +86,7 @@ class OverDriveWebScraper:
                 f"OverDrive Marketplace URL loading timed out: {url}"
             ) from None
 
+    def _get_row_count(self):
         try:
             total_rows_el = self.driver.find_element(
                 By.ID, "column_TotalFormatted-textInnerEl"
@@ -80,11 +97,7 @@ class OverDriveWebScraper:
             raise OverDriveWebScraperError(
                 "No OverDrive Marketplace total checkouts element found"
             ) from None
-
-        # The text should be in the format "Checkouts (1,234)"
-        count = total_rows_el.text.replace(",", "").replace(".", "").replace(" ", "")
-        self.driver.quit()
-        return int(count[count.find("(") + 1 : count.find(")")])
+        return total_rows_el.text.replace(",", "").replace(".", "").replace(" ", "")
 
     def _log_in(self):
         self.logger.info("Logging into OverDrive")
@@ -107,6 +120,7 @@ class OverDriveWebScraper:
             raise OverDriveWebScraperError(
                 f"Login page elements not found: {e}"
             ) from None
+        time.sleep(4)
         if self.driver.current_url == _LOGIN_URL:
             self.driver.quit()
             self.logger.error("Login failed")

--- a/helpers/overdrive_web_scraper.py
+++ b/helpers/overdrive_web_scraper.py
@@ -106,6 +106,9 @@ class OverDriveWebScraper:
     def _log_in(self):
         self.logger.info("Logging into OverDrive")
         self.driver.get(_LOGIN_URL)
+        # This sleep allows the cookies pop up modal time to load which has no close button until it is
+        # done loading causing the login to fail
+        time.sleep(4)
         try:
             # Click out of cookie selection pop-up if present
             cookie_settings = self.driver.find_elements(

--- a/helpers/overdrive_web_scraper.py
+++ b/helpers/overdrive_web_scraper.py
@@ -46,30 +46,20 @@ class OverDriveWebScraper:
             self.chrome_options.add_argument(option)
 
     def get_count(self, start_date, end_date):
-        self.logger.info(
-            f"Getting OverDrive Marketplace record count for the range {start_date} - {end_date}"
-        )
+        if start_date == end_date:
+            self.logger.info(
+                f"Getting OverDrive Marketplace record count for {start_date}"
+            )
+        else:
+            self.logger.info(
+                f"Getting OverDrive Marketplace record count for the range {start_date} - {end_date}"
+            )
         url = _BASE_URL.format("Checkouts") + quote(
             _URL_DATA.format(
                 start=start_date, end=end_date, code="null", name="null", limit="50"
             )
         )
-        self._access_page(url)
-        # The text should be in the format "Checkouts (1,234)"
-        count = self._get_row_count()
 
-        return int(count[count.find("(") + 1 : count.find(")")])
-
-    def overdrive_login(self):
-        self.logger.info("Opening Chrome web driver")
-        self.driver = webdriver.Chrome(options=self.chrome_options)
-        self.driver.maximize_window()
-        self._log_in()
-
-    def quit_driver(self):
-        self.driver.quit()
-
-    def _access_page(self, url):
         try:
             self.driver.get(url)
             WebDriverWait(self.driver, timeout=30).until(
@@ -85,6 +75,20 @@ class OverDriveWebScraper:
             raise OverDriveWebScraperError(
                 f"OverDrive Marketplace URL loading timed out: {url}"
             ) from None
+
+        # The text should be in the format "Checkouts (1,234)"
+        count = self._get_row_count()
+
+        return int(count[count.find("(") + 1 : count.find(")")])
+
+    def overdrive_login(self):
+        self.logger.info("Opening Chrome web driver")
+        self.driver = webdriver.Chrome(options=self.chrome_options)
+        self.driver.maximize_window()
+        self._log_in()
+
+    def quit_driver(self):
+        self.driver.quit()
 
     def _get_row_count(self):
         try:

--- a/helpers/overdrive_web_scraper.py
+++ b/helpers/overdrive_web_scraper.py
@@ -124,6 +124,9 @@ class OverDriveWebScraper:
             raise OverDriveWebScraperError(
                 f"Login page elements not found: {e}"
             ) from None
+        # This sleep function gives the login attempt some time to finish
+        # it sometimes would error out only because the browser hadn't loaded
+        # the webpage and updated the url
         time.sleep(4)
         if self.driver.current_url == _LOGIN_URL:
             self.driver.quit()

--- a/helpers/query_helper.py
+++ b/helpers/query_helper.py
@@ -158,19 +158,27 @@ _REDSHIFT_HOURS_LOCATION_ID_QUERY = """
         SELECT sierra_code FROM {branch_codes_table}
     );"""
 
-_REDSHIFT_EBOOK_QUERY = "SELECT COUNT(*) FROM {table} WHERE transaction_et = '{date}';"
+_REDSHIFT_DAILY_EBOOK_QUERY = "SELECT COUNT(*) FROM {table} WHERE transaction_et = '{date}';"
 
-_REDSHIFT_OVERDRIVE_PLATFORMS_DUPLICATE_QUERY = """
-    SELECT DISTINCT platform 
-    FROM {table} 
-    WHERE transaction_et = '{date}'
-    AND transaction_checksum = '{checksum}';"""
+_REDSHIFT_MONTHLY_EBOOK_QUERY = "SELECT COUNT(*) FROM {table} WHERE transaction_et BETWEEN '{start_date}' AND '{end_date}';"
 
-_REDSHIFT_OVERDRIVE_FIND_DUPLICATE_CHECKSUMS_QUERY = """
-    SELECT transaction_checksum 
-    FROM {table} 
-    WHERE transaction_et = '{date}'
-    GROUP BY transaction_checksum HAVING COUNT(*) > 1;"""
+_REDSHIFT_OVERDRIVE_DAILY_PLATFORM_QUERY = """
+    SELECT COALESCE(SUM(platform_count - 1), 0) FROM (
+        SELECT COUNT(DISTINCT platform) AS platform_count
+        FROM {table}
+        WHERE transaction_et = '{date}'
+        GROUP BY transaction_checksum
+        HAVING COUNT(DISTINCT platform) > 1
+    );"""
+
+_REDSHIFT_OVERDRIVE_MONTHLY_PLATFORM_QUERY = """
+    SELECT COALESCE(SUM(platform_count - 1), 0) FROM (
+        SELECT COUNT(DISTINCT platform) AS platform_count
+        FROM {table}
+        WHERE transaction_et BETWEEN '{start_date}' AND '{end_date}'
+        GROUP BY transaction_checksum
+        HAVING COUNT(DISTINCT platform) > 1
+    );"""
 
 _REDSHIFT_NEW_PATRONS_QUERY = """
     SELECT creation_date_et, COUNT(patron_id)
@@ -355,20 +363,27 @@ def build_redshift_hours_location_id_query(hours_table, branch_codes_table, date
     )
 
 
-def build_redshift_ebook_query(table, date):
+def build_redshift_daily_ebook_query(table, date):
     # Used for both cloudLibrary and OverDrive tests
-    return _REDSHIFT_EBOOK_QUERY.format(table=table, date=date)
+    return _REDSHIFT_DAILY_EBOOK_QUERY.format(table=table, date=date)
 
 
-def build_redshift_overdrive_duplicate_checksum_query(table, date):
-    return _REDSHIFT_OVERDRIVE_FIND_DUPLICATE_CHECKSUMS_QUERY.format(
+def build_redshift_monthly_ebook_query(table, start_date, end_date):
+    # Used for both cloudLibrary and OverDrive tests
+    return _REDSHIFT_MONTHLY_EBOOK_QUERY.format(
+        table=table, start_date=start_date, end_date=end_date
+    )
+
+
+def build_redshift_daily_overdrive_platform_query(table, date):
+    return _REDSHIFT_OVERDRIVE_DAILY_PLATFORM_QUERY.format(
         table=table, date=date
     )
 
 
-def build_redshift_overdrive_duplicate_platform_query(table, date, checksum):
-    return _REDSHIFT_OVERDRIVE_PLATFORMS_DUPLICATE_QUERY.format(
-        table=table, date=date, checksum=checksum
+def build_redshift_monthly_overdrive_platform_query(table, start_date, end_date):
+    return _REDSHIFT_OVERDRIVE_MONTHLY_PLATFORM_QUERY.format(
+        table=table, start_date=start_date, end_date=end_date
     )
 
 

--- a/helpers/query_helper.py
+++ b/helpers/query_helper.py
@@ -158,7 +158,9 @@ _REDSHIFT_HOURS_LOCATION_ID_QUERY = """
         SELECT sierra_code FROM {branch_codes_table}
     );"""
 
-_REDSHIFT_DAILY_EBOOK_QUERY = "SELECT COUNT(*) FROM {table} WHERE transaction_et = '{date}';"
+_REDSHIFT_DAILY_EBOOK_QUERY = (
+    "SELECT COUNT(*) FROM {table} WHERE transaction_et = '{date}';"
+)
 
 _REDSHIFT_MONTHLY_EBOOK_QUERY = "SELECT COUNT(*) FROM {table} WHERE transaction_et BETWEEN '{start_date}' AND '{end_date}';"
 
@@ -376,9 +378,7 @@ def build_redshift_monthly_ebook_query(table, start_date, end_date):
 
 
 def build_redshift_daily_overdrive_platform_query(table, date):
-    return _REDSHIFT_OVERDRIVE_DAILY_PLATFORM_QUERY.format(
-        table=table, date=date
-    )
+    return _REDSHIFT_OVERDRIVE_DAILY_PLATFORM_QUERY.format(table=table, date=date)
 
 
 def build_redshift_monthly_overdrive_platform_query(table, start_date, end_date):

--- a/helpers/query_helper.py
+++ b/helpers/query_helper.py
@@ -161,8 +161,9 @@ _REDSHIFT_HOURS_LOCATION_ID_QUERY = """
 _REDSHIFT_DAILY_EBOOK_QUERY = (
     "SELECT COUNT(*) FROM {table} WHERE transaction_et = '{date}';"
 )
-
-_REDSHIFT_MONTHLY_EBOOK_QUERY = "SELECT COUNT(*) FROM {table} WHERE transaction_et BETWEEN '{start_date}' AND '{end_date}';"
+#  the inclusive start_date is so that the 36th day is checked the exclusive end_date is so that for this check it will not be counted
+#  since the daily check will already have been run for just the end_date, so both alarms wont trigger for the same issue
+_REDSHIFT_MONTHLY_EBOOK_QUERY = "SELECT COUNT(*) FROM {table} WHERE transaction_et >= '{start_date}' AND transaction_et < '{end_date}';"
 
 _REDSHIFT_OVERDRIVE_DAILY_PLATFORM_QUERY = """
     SELECT COALESCE(SUM(platform_count - 1), 0) FROM (
@@ -177,7 +178,7 @@ _REDSHIFT_OVERDRIVE_MONTHLY_PLATFORM_QUERY = """
     SELECT COALESCE(SUM(platform_count - 1), 0) FROM (
         SELECT COUNT(DISTINCT platform) AS platform_count
         FROM {table}
-        WHERE transaction_et BETWEEN '{start_date}' AND '{end_date}'
+        WHERE transaction_et >= '{start_date}' AND transaction_et < '{end_date}'
         GROUP BY transaction_checksum
         HAVING COUNT(DISTINCT platform) > 1
     );"""

--- a/tests/alarms/models/test_cloudlibrary_alarms.py
+++ b/tests/alarms/models/test_cloudlibrary_alarms.py
@@ -16,7 +16,7 @@ class TestCloudLibraryAlarms:
 
     def test_run_checks_no_alarm(self, test_instance, mocker, caplog):
         mock_redshift_query = mocker.patch(
-            "alarms.models.cloudlibrary_alarms.build_redshift_ebook_query",
+            "alarms.models.cloudlibrary_alarms.build_redshift_daily_ebook_query",
             return_value="redshift cl query",
         )
         test_instance.redshift_client.execute_query.return_value = ([10],)
@@ -34,7 +34,7 @@ class TestCloudLibraryAlarms:
 
     def test_run_checks_alarm(self, test_instance, mocker, caplog):
         mock_redshift_query = mocker.patch(
-            "alarms.models.cloudlibrary_alarms.build_redshift_ebook_query",
+            "alarms.models.cloudlibrary_alarms.build_redshift_daily_ebook_query",
             return_value="redshift cl query",
         )
         test_instance.redshift_client.execute_query.return_value = ([0],)

--- a/tests/alarms/models/test_overdrive_checkouts_alarms.py
+++ b/tests/alarms/models/test_overdrive_checkouts_alarms.py
@@ -42,23 +42,23 @@ class TestOverDriveCheckoutsAlarms:
         assert caplog.text == ""
         assert test_instance.redshift_client.connect.call_count == 3
         test_instance.overdrive_client.get_count.assert_called_once_with(
-            test_instance.daily_date_to_test, test_instance.daily_date_to_test
+            test_instance.daily_test_date, test_instance.daily_test_date
         )
         mock_redshift_query.assert_has_calls(
             [
                 mocker.call(
                     "patron_overdrive_checkouts_test_redshift_db",
-                    test_instance.daily_date_to_test,
+                    test_instance.daily_test_date,
                 ),
                 mocker.call(
                     "title_overdrive_checkouts_test_redshift_db",
-                    test_instance.daily_date_to_test,
+                    test_instance.daily_test_date,
                 ),
             ]
         )
         mock_duplicate_query.assert_called_once_with(
             "patron_overdrive_checkouts_test_redshift_db",
-            test_instance.daily_date_to_test,
+            test_instance.daily_test_date,
         )
         test_instance.redshift_client.execute_query.assert_has_calls(
             [
@@ -189,11 +189,11 @@ class TestOverDriveCheckoutsAlarms:
         test_instance.overdrive_client.get_count.assert_has_calls(
             [
                 mocker.call(
-                    test_instance.daily_date_to_test, test_instance.daily_date_to_test
+                    test_instance.daily_test_date, test_instance.daily_test_date
                 ),
                 mocker.call(
                     test_instance.monthly_test_start_date,
-                    test_instance.daily_date_to_test,
+                    test_instance.daily_test_date,
                 ),
             ]
         )
@@ -202,17 +202,17 @@ class TestOverDriveCheckoutsAlarms:
                 mocker.call(
                     "patron_overdrive_checkouts_test_redshift_db",
                     test_instance.monthly_test_start_date,
-                    test_instance.daily_date_to_test,
+                    test_instance.daily_test_date,
                 ),
                 mocker.call(
                     "title_overdrive_checkouts_test_redshift_db",
                     test_instance.monthly_test_start_date,
-                    test_instance.daily_date_to_test,
+                    test_instance.daily_test_date,
                 ),
             ]
         )
         mock_monthly_overdrive.assert_called_once_with(
             "patron_overdrive_checkouts_test_redshift_db",
             test_instance.monthly_test_start_date,
-            test_instance.daily_date_to_test,
+            test_instance.daily_test_date,
         )

--- a/tests/alarms/models/test_overdrive_checkouts_alarms.py
+++ b/tests/alarms/models/test_overdrive_checkouts_alarms.py
@@ -193,7 +193,7 @@ class TestOverDriveCheckoutsAlarms:
                 ),
                 mocker.call(
                     test_instance.monthly_test_start_date,
-                    test_instance.monthly_test_end_date,
+                    test_instance.daily_date_to_test,
                 ),
             ]
         )
@@ -202,17 +202,17 @@ class TestOverDriveCheckoutsAlarms:
                 mocker.call(
                     "patron_overdrive_checkouts_test_redshift_db",
                     test_instance.monthly_test_start_date,
-                    test_instance.monthly_test_end_date,
+                    test_instance.daily_date_to_test,
                 ),
                 mocker.call(
                     "title_overdrive_checkouts_test_redshift_db",
                     test_instance.monthly_test_start_date,
-                    test_instance.monthly_test_end_date,
+                    test_instance.daily_date_to_test,
                 ),
             ]
         )
         mock_monthly_overdrive.assert_called_once_with(
             "patron_overdrive_checkouts_test_redshift_db",
             test_instance.monthly_test_start_date,
-            test_instance.monthly_test_end_date,
+            test_instance.daily_date_to_test,
         )

--- a/tests/alarms/models/test_overdrive_checkouts_alarms.py
+++ b/tests/alarms/models/test_overdrive_checkouts_alarms.py
@@ -26,11 +26,11 @@ class TestOverDriveCheckoutsAlarms:
 
     def test_run_checks_no_alarm(self, test_instance, mocker, caplog):
         mock_redshift_query = mocker.patch(
-            "alarms.models.overdrive_checkouts_alarms.build_redshift_ebook_query",
+            "alarms.models.overdrive_checkouts_alarms.build_redshift_daily_ebook_query",
             return_value="redshift od query",
         )
         mock_duplicate_query = mocker.patch(
-            "alarms.models.overdrive_checkouts_alarms.build_redshift_overdrive_duplicate_checksum_query",
+            "alarms.models.overdrive_checkouts_alarms.build_redshift_daily_overdrive_platform_query",
             return_value="redshift od duplicate query",
         )
         test_instance.redshift_client.execute_query.side_effect = [([10],), ()] * 2
@@ -41,34 +41,39 @@ class TestOverDriveCheckoutsAlarms:
 
         assert caplog.text == ""
         assert test_instance.redshift_client.connect.call_count == 3
-        test_instance.overdrive_client.get_count.assert_called_once_with(test_instance.date_to_test)
+        test_instance.overdrive_client.get_count.assert_called_once_with(
+            test_instance.daily_date_to_test, test_instance.daily_date_to_test
+        )
         mock_redshift_query.assert_has_calls(
             [
                 mocker.call(
                     "patron_overdrive_checkouts_test_redshift_db",
-                    test_instance.date_to_test,
+                    test_instance.daily_date_to_test,
                 ),
                 mocker.call(
                     "title_overdrive_checkouts_test_redshift_db",
-                    test_instance.date_to_test,
+                    test_instance.daily_date_to_test,
                 ),
             ]
         )
-        mock_duplicate_query.assert_called_once_with("patron_overdrive_checkouts_test_redshift_db", test_instance.date_to_test)
+        mock_duplicate_query.assert_called_once_with(
+            "patron_overdrive_checkouts_test_redshift_db",
+            test_instance.daily_date_to_test,
+        )
         test_instance.redshift_client.execute_query.assert_has_calls(
             [
                 mocker.call("redshift od query"),
                 mocker.call("redshift od duplicate query"),
             ]
         )
-        assert test_instance.redshift_client.close_connection.call_count == 2
+        assert test_instance.redshift_client.close_connection.call_count == 3
 
     def test_run_checks_unequal_counts_alarm(self, test_instance, mocker, caplog):
         mocker.patch(
-            "alarms.models.overdrive_checkouts_alarms.build_redshift_ebook_query"
+            "alarms.models.overdrive_checkouts_alarms.build_redshift_daily_ebook_query"
         )
         mocker.patch(
-            "alarms.models.overdrive_checkouts_alarms.build_redshift_overdrive_duplicate_checksum_query"
+            "alarms.models.overdrive_checkouts_alarms.build_redshift_daily_overdrive_platform_query"
         )
         test_instance.redshift_client.execute_query.side_effect = [([10],), ()] * 2
         test_instance.overdrive_client.get_count.return_value = 20
@@ -91,19 +96,17 @@ class TestOverDriveCheckoutsAlarms:
         self, test_instance, mocker, caplog
     ):
         mocker.patch(
-            "alarms.models.overdrive_checkouts_alarms.build_redshift_ebook_query",
+            "alarms.models.overdrive_checkouts_alarms.build_redshift_daily_ebook_query",
         )
         mocker.patch(
-            "alarms.models.overdrive_checkouts_alarms.build_redshift_overdrive_duplicate_checksum_query"
-        )
-        mocker.patch(
-            "alarms.models.overdrive_checkouts_alarms.build_redshift_overdrive_duplicate_platform_query"
+            "alarms.models.overdrive_checkouts_alarms.build_redshift_daily_overdrive_platform_query"
         )
         test_instance.redshift_client.execute_query.side_effect = [
-            ([11],),(["jQhmtNm/QuLk"],),
-            (["OverDrive Read"], ["Kindle Book"]), ([10],)
+            ([19],),
+            ([10],),
+            ([9],),
         ]
-        test_instance.overdrive_client.get_count.return_value = 10
+        test_instance.overdrive_client.get_count.return_value = 9
 
         with caplog.at_level(logging.ERROR):
             test_instance.run_checks()
@@ -111,10 +114,10 @@ class TestOverDriveCheckoutsAlarms:
 
     def test_run_checks_no_records_alarm(self, test_instance, mocker, caplog):
         mocker.patch(
-            "alarms.models.overdrive_checkouts_alarms.build_redshift_ebook_query"
+            "alarms.models.overdrive_checkouts_alarms.build_redshift_daily_ebook_query"
         )
         mocker.patch(
-            "alarms.models.overdrive_checkouts_alarms.build_redshift_overdrive_duplicate_checksum_query"
+            "alarms.models.overdrive_checkouts_alarms.build_redshift_daily_overdrive_platform_query"
         )
         test_instance.redshift_client.execute_query.side_effect = [([0],), ()] * 2
         test_instance.overdrive_client.get_count.return_value = 0
@@ -135,7 +138,7 @@ class TestOverDriveCheckoutsAlarms:
             "alarms.models.overdrive_checkouts_alarms.check_no_records_found_alarm"
         )
         mock_redshift_query = mocker.patch(
-            "alarms.models.overdrive_checkouts_alarms.build_redshift_ebook_query"
+            "alarms.models.overdrive_checkouts_alarms.build_redshift_daily_ebook_query"
         )
         test_instance.overdrive_client.get_count.side_effect = OverDriveWebScraperError(
             "mock error"
@@ -151,3 +154,65 @@ class TestOverDriveCheckoutsAlarms:
         test_instance.redshift_client.close_connection.assert_not_called()
         mock_mismatch_alarm_helper.assert_not_called()
         mock_no_recs_alarm_helper.assert_not_called()
+
+    def test_run_checks_weekly_execution(self, test_instance, mocker, caplog):
+        # Mock yesterday_date to return 3 (Thursday) for weekday()
+        mock_date = mocker.MagicMock(wraps=test_instance.yesterday_date)
+        mock_date.weekday.return_value = 3
+        test_instance.yesterday_date = mock_date
+
+        mock_monthly_ebook = mocker.patch(
+            "alarms.models.overdrive_checkouts_alarms.build_redshift_monthly_ebook_query",
+            return_value="monthly count q",
+        )
+
+        mock_monthly_overdrive = mocker.patch(
+            "alarms.models.overdrive_checkouts_alarms.build_redshift_monthly_overdrive_platform_query",
+            return_value="monthly disc q",
+        )
+
+        test_instance.overdrive_client.get_count.return_value = 10
+
+        test_instance.redshift_client.execute_query.side_effect = [
+            ([10],),
+            ([0],),
+            ([10],),
+            ([10],),
+            ([0],),
+            ([10],),
+        ]
+
+        with caplog.at_level(logging.ERROR):
+            test_instance.run_checks()
+
+        assert caplog.text == ""
+        test_instance.overdrive_client.get_count.assert_has_calls(
+            [
+                mocker.call(
+                    test_instance.daily_date_to_test, test_instance.daily_date_to_test
+                ),
+                mocker.call(
+                    test_instance.monthly_test_start_date,
+                    test_instance.monthly_test_end_date,
+                ),
+            ]
+        )
+        mock_monthly_ebook.assert_has_calls(
+            [
+                mocker.call(
+                    "patron_overdrive_checkouts_test_redshift_db",
+                    test_instance.monthly_test_start_date,
+                    test_instance.monthly_test_end_date,
+                ),
+                mocker.call(
+                    "title_overdrive_checkouts_test_redshift_db",
+                    test_instance.monthly_test_start_date,
+                    test_instance.monthly_test_end_date,
+                ),
+            ]
+        )
+        mock_monthly_overdrive.assert_called_once_with(
+            "patron_overdrive_checkouts_test_redshift_db",
+            test_instance.monthly_test_start_date,
+            test_instance.monthly_test_end_date,
+        )

--- a/tests/helpers/test_overdrive_web_scraper.py
+++ b/tests/helpers/test_overdrive_web_scraper.py
@@ -22,11 +22,9 @@ _TEST_URL = (
     "%22%3A0%2C%22limit%22%3A50%2C%22sort%22%3A%5B%5D%7D%7D"
 )
 
+
 class TestOverDriveWebScraper:
     def test_get_count(self, mocker):
-        mock_log_in = mocker.patch(
-            "helpers.overdrive_web_scraper.OverDriveWebScraper._log_in"
-        )
         mock_waiter = mocker.patch("helpers.overdrive_web_scraper.WebDriverWait.until")
 
         mock_driver = mocker.MagicMock()
@@ -37,21 +35,17 @@ class TestOverDriveWebScraper:
         test_instance = OverDriveWebScraper(
             "mock_overdrive_username", "mock_overdrive_password"
         )
+        test_instance.driver = mock_driver
 
-        assert test_instance.get_count("2023-05-31") == 1234
+        assert test_instance.get_count("2023-05-31", "2023-05-31") == 1234
 
-        mock_driver.maximize_window.assert_called_once()
-        mock_log_in.assert_called_once()
         mock_driver.get.assert_called_once_with(_TEST_URL)
         mock_waiter.assert_called_once()
         mock_driver.find_element.assert_called_once_with(
-            By.ID, "column_TotalFormatted-textInnerEl")
-        mock_driver.quit.assert_called_once()
+            By.ID, "column_TotalFormatted-textInnerEl"
+        )
 
     def test_get_count_timeout(self, mocker):
-        mocker.patch(
-            "helpers.overdrive_web_scraper.OverDriveWebScraper._log_in"
-        )
         mocker.patch(
             "helpers.overdrive_web_scraper.WebDriverWait.until",
             side_effect=exceptions.TimeoutException,
@@ -64,17 +58,15 @@ class TestOverDriveWebScraper:
         test_instance = OverDriveWebScraper(
             "mock_overdrive_username", "mock_overdrive_password"
         )
+        test_instance.driver = mock_driver
 
         with pytest.raises(OverDriveWebScraperError):
-            test_instance.get_count("2023-05-31")
+            test_instance.get_count("2023-05-31", "2023-05-31")
 
         mock_driver.quit.assert_called_once()
         mock_driver.find_element.assert_not_called()
 
     def test_get_count_no_element(self, mocker):
-        mocker.patch(
-            "helpers.overdrive_web_scraper.OverDriveWebScraper._log_in"
-        )
         mocker.patch("helpers.overdrive_web_scraper.WebDriverWait.until")
 
         mock_driver = mocker.MagicMock()
@@ -85,9 +77,10 @@ class TestOverDriveWebScraper:
         test_instance = OverDriveWebScraper(
             "mock_overdrive_username", "mock_overdrive_password"
         )
+        test_instance.driver = mock_driver
 
         with pytest.raises(OverDriveWebScraperError):
-            test_instance.get_count("2023-05-31")
+            test_instance.get_count("2023-05-31", "2023-05-31")
 
         mock_driver.quit.assert_called_once()
 
@@ -101,7 +94,10 @@ class TestOverDriveWebScraper:
         mock_password_el = mocker.MagicMock()
         mock_submit_el = mocker.MagicMock()
         test_instance.driver.find_element.side_effect = [
-            mock_username_el, mock_password_el, mock_submit_el]
+            mock_username_el,
+            mock_password_el,
+            mock_submit_el,
+        ]
 
         test_instance._log_in()
 
@@ -109,9 +105,12 @@ class TestOverDriveWebScraper:
             "https://marketplace.overdrive.com/Account/Login"
         )
         test_instance.driver.find_element.assert_has_calls(
-            [mocker.call(By.ID, "UserName"),
-             mocker.call(By.ID, "Password"),
-             mocker.call(By.XPATH, "//input[@type='submit']")])
+            [
+                mocker.call(By.ID, "UserName"),
+                mocker.call(By.ID, "Password"),
+                mocker.call(By.XPATH, "//input[@type='submit']"),
+            ]
+        )
         test_instance.driver.find_elements.assert_called_once_with(
             By.XPATH, "//*[@id='dialogModalContainer']/dialog/button"
         )
@@ -128,7 +127,8 @@ class TestOverDriveWebScraper:
         test_instance.driver.current_url = "fake url"
         test_instance.driver.find_element.side_effect = [
             mocker.MagicMock(),
-            exceptions.NoSuchElementException]
+            exceptions.NoSuchElementException,
+        ]
 
         with pytest.raises(OverDriveWebScraperError):
             test_instance._log_in()


### PR DESCRIPTION
Update the Overdrive Alarm that handles the daily check for overdrive inconsistencies with a new alarm that runs once a week on Friday and will send an alert if the count we have in redshift does not match whats in Overdrive.