### PR TITLE
[de-678] Update the OverDrive website query to use the correct dates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
-## 2026-07-07
-### Added
+## 2026-07-24
+### Fixed
 - Fix bug in the OverDrive monthly inconsistencies alarm caused by incorrect date range for the OverDrive website query
 
 ## 2026-07-07

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 2026-07-07
 ### Added
+- Fix bug in the OverDrive monthly inconsistencies alarm caused by incorrect date range for the OverDrive website query
+
+## 2026-07-07
+### Added
 - Alarms to handle inconsistencies between Overdrive and Redshift
 
 ## 2026-06-16

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Currently, the code will log an error (triggering an alarm to fire) under the fo
 * When the number of PC reserve records in Envisionware and Redshift differs for the previous day
 * When there are no PC reserve records in Sierra for the previous day
 * When the number of OverDrive checkout records online (via OverDrive Marketplace) and in Redshift from 5 days prior differs 
+* When the number of OverDrive checkout records online (via OverDrive Marketplace) and in Redshift from 36 to 6 days prior differs 
 * When there are no OverDrive checkout records online (via OverDrive Marketplace) from 5 days ago
 * When the number of newly created/deleted patron records in Sierra and Redshift differs for any day in the previous week
 * When there are no newly created patron records in Sierra for the previous any day in the previous week

--- a/alarms/models/overdrive_checkouts_alarms.py
+++ b/alarms/models/overdrive_checkouts_alarms.py
@@ -49,7 +49,8 @@ class OverDriveCheckoutsAlarms(Alarm):
                         f"Running weekly check for inconsistencies between overdrive and redshift for the dates between {self.monthly_test_start_date} - {self.daily_test_date}"
                     )
                     monthly_overdrive_count = self.overdrive_client.get_count(
-                        self.monthly_test_start_date, self.daily_test_date
+                        self.monthly_test_start_date,
+                        self.daily_test_date - timedelta(1),
                     )
                     self._run_redshift_checks(
                         monthly_overdrive_count, monthly_check=True

--- a/alarms/models/overdrive_checkouts_alarms.py
+++ b/alarms/models/overdrive_checkouts_alarms.py
@@ -45,12 +45,13 @@ class OverDriveCheckoutsAlarms(Alarm):
             # The 'weekday' method returns Thursday as 3 so this check will run every Friday
             if self.yesterday_date.weekday() == 3:
                 try:
+                    monthly_test_end_date = self.daily_test_date - timedelta(1)
                     self.logger.info(
-                        f"Running weekly check for inconsistencies between overdrive and redshift for the dates between {self.monthly_test_start_date} - {self.daily_test_date}"
+                        f"Running weekly check for inconsistencies between OverDrive and Redshift for the dates between {self.monthly_test_start_date} - {monthly_test_end_date}"
                     )
                     monthly_overdrive_count = self.overdrive_client.get_count(
                         self.monthly_test_start_date,
-                        self.daily_test_date - timedelta(1),
+                        monthly_test_end_date,
                     )
                     self._run_redshift_checks(
                         monthly_overdrive_count, monthly_check=True

--- a/tests/alarms/models/test_overdrive_checkouts_alarms.py
+++ b/tests/alarms/models/test_overdrive_checkouts_alarms.py
@@ -1,3 +1,4 @@
+from datetime import timedelta
 import logging
 import pytest
 
@@ -193,7 +194,7 @@ class TestOverDriveCheckoutsAlarms:
                 ),
                 mocker.call(
                     test_instance.monthly_test_start_date,
-                    test_instance.daily_test_date,
+                    test_instance.daily_test_date - timedelta(1),
                 ),
             ]
         )


### PR DESCRIPTION
Update the date used in the OverDrive monthly query so that the "end date" ignores the last day, an "exlcusive" query, like the sql used for the redshift queries.